### PR TITLE
Fix TCK duplicate initialization call and package name requirement

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckResource.java
@@ -58,7 +58,7 @@ public class TckResource {
     public TckResult runTck(@PathParam("name") String testName, @DefaultValue("true") @QueryParam(VERBOSE) boolean isVerbose) {
         test.before();
 
-        TckResult results = test.runTck(lraClient, testName, isVerbose);
+        TckResult results = test.runTck(testName, isVerbose);
 
         test.after();
 

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckResult.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckResult.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-class TckResult {
+public class TckResult {
     private List<TckMethodResult> tests;
     private List<TckMethodResult> results;
     private List<String> failures;

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
@@ -78,10 +78,8 @@ public class TckTests {
         initTck(lraClient);
     }
 
-    public TckResult runTck(LRAClient lraClient, String testname, boolean verbose) {
+    public TckResult runTck(String testname, boolean verbose) {
         TckResult run = new TckResult();
-
-        initTck(lraClient);
 
         run.add("timeLimit", TckTests::timeLimit, verbose);
         run.add("startLRA", TckTests::startLRA, verbose);


### PR DESCRIPTION
This PR covers:

- duplicate `TckTests#initTck(LRAClient)` initialization calls - implementation should first call `TckTests#beforeClass` method as it is expected by the testing framework (example can be seen in `TckResource`) 
- making `TckResult` public - IMHO the spec should not be forcing package naming 