### PR TITLE
Issue6 Include extra tests for time limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ target
 .settings
 .metadata
 .checkstyle
-

--- a/api/src/main/java/org/eclipse/microprofile/lra/client/LRAInfo.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/client/LRAInfo.java
@@ -37,22 +37,13 @@ public interface LRAInfo {
     String getClientId();
 
     /**
-     * @return  true if lra was successfully completed, false otherwise
-     */
-    boolean isComplete();
-
-    /**
-     * @return  true if lra was compensated, false otherwise
-     */
-    boolean isCompensated();
-
-    /**
      * @return  true if recovery is in progress on the lra, false otherwise
      */
     boolean isRecovering();
 
     /**
-     * @return  true if lra is in active state right now, false otherwise
+     * Test if the LRA has not been asked to close or cancel.
+     * @return  true if lra is in active state right now, false otherwise.
      */
     boolean isActive();
 
@@ -60,4 +51,12 @@ public interface LRAInfo {
      * @return  true if lra is top level (not nested), false otherwise
      */
     boolean isTopLevel();
+
+    /**
+     * The current status of this LRA. Valid values match
+     * {@link org.eclipse.microprofile.lra.annotation.CompensatorStatus}
+     * @return the status of the LRA. A null value or the empty string
+     * means that the LRA is still active ({@link LRAInfo#isActive()})
+     */
+    String getStatus();
 }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
@@ -39,6 +39,7 @@ import javax.ws.rs.core.Response;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
@@ -149,9 +150,16 @@ public class TckTests {
     @Before
     public void before() {
         try {
+            String rcPath = System.getProperty(LRA_RECOVERY_PATH_KEY, "lra-recovery-coordinator");
+
             msTarget = msClient.target(URI.create(new URL(micrserviceBaseUrl, "/").toExternalForm()));
+<<<<<<< HEAD
             recoveryTarget = rcClient.target(URI.create(rcBaseUrl.toExternalForm()));
         } catch (MalformedURLException e) {
+=======
+            recoveryTarget = rcClient.target(rcBaseUrl.toURI());
+        } catch (MalformedURLException | URISyntaxException  e) {
+>>>>>>> issue7 Context propagation across non-LRA aware services
             throw new RuntimeException(e);
         }
     }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ActivityController.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ActivityController.java
@@ -76,6 +76,10 @@ import static org.eclipse.microprofile.lra.client.LRAClient.LRA_HTTP_RECOVERY_HE
 public class ActivityController {
     public static final String ACTIVITIES_PATH = "activities";
     public static final String ACCEPT_WORK = "acceptWork";
+
+    static final String WORK_RESOURCE_PATH = "/work";
+    static final String MANDATORY_LRA_RESOURCE_PATH = "/mandatory";
+
     private static final Logger LOGGER = Logger.getLogger(ActivityController.class.getName());
 
     static final String WORK_RESOURCE_PATH = "/work";
@@ -345,6 +349,17 @@ public class ActivityController {
 
     @PUT
     @Path(MANDATORY_LRA_RESOURCE_PATH)
+<<<<<<< HEAD
+=======
+    @LRA(LRA.Type.MANDATORY)
+    public Response activityWithMandatoryLRA(@HeaderParam(LRA_HTTP_RECOVERY_HEADER) String rcvId,
+                                             @HeaderParam(LRA_HTTP_HEADER) String lraId) {
+        return activityWithLRA(rcvId, lraId);
+    }
+
+    @PUT
+    @Path("/nestedActivity")
+>>>>>>> issue7 Context propagation across non-LRA aware services
     @LRA(LRA.Type.MANDATORY)
     public Response activityWithMandatoryLRA(@HeaderParam(LRA_HTTP_RECOVERY_HEADER) String rcvId,
                                              @HeaderParam(LRA_HTTP_HEADER) String lraId) {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/StandardController.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/StandardController.java
@@ -64,7 +64,7 @@ public class StandardController {
             return Response.status(Response.Status.PRECONDITION_FAILED).entity(Entity.text("LRA context was not propagated")).build();
         }
 
-        return Response.ok(id).build();
+        return Response.ok().build();
     }
 
     private String checkStatusAndClose(Response response, int expected, boolean readEntity, WebTarget webTarget) {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/TimedParticipant.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/TimedParticipant.java
@@ -1,0 +1,266 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.lra.tck.participant.api;
+
+import org.eclipse.microprofile.lra.annotation.Compensate;
+import org.eclipse.microprofile.lra.annotation.CompensatorStatus;
+import org.eclipse.microprofile.lra.annotation.Complete;
+import org.eclipse.microprofile.lra.annotation.Forget;
+import org.eclipse.microprofile.lra.annotation.LRA;
+import org.eclipse.microprofile.lra.annotation.Status;
+import org.eclipse.microprofile.lra.annotation.TimeLimit;
+import org.eclipse.microprofile.lra.client.IllegalLRAStateException;
+import org.eclipse.microprofile.lra.client.LRAClient;
+import org.eclipse.microprofile.lra.tck.participant.model.Activity;
+import org.eclipse.microprofile.lra.tck.participant.service.ActivityService;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@ApplicationScoped
+@Path(TimedParticipant.ACTIVITIES_PATH2)
+@LRA(LRA.Type.SUPPORTS)
+public class TimedParticipant {
+    public static final String ACTIVITIES_PATH2 = "timedactivities";
+    public static final String ACCEPT_WORK = "/acceptWork";
+    public static final String TIME_LIMIT_SUPPORTS_LRA = "/timeLimitSupportsLRA";
+
+    private static final AtomicInteger COMPLETED_COUNT = new AtomicInteger(0);
+    private static final AtomicInteger COMPENSATED_COUNT = new AtomicInteger(0);
+
+    @Inject
+    private LRAClient lraClient;
+
+    @Context
+    private UriInfo context;
+
+    @Inject
+    private ActivityService activityService;
+
+    /*
+     Performing a GET on the participant URL will return the current status of the participant
+     {@link CompensatorStatus}, or 404 if the participant is no longer present.
+     */
+    @GET
+    @Path("/status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Status
+    @LRA(LRA.Type.NOT_SUPPORTED)
+    public Response status(@HeaderParam(LRAClient.LRA_HTTP_HEADER) String lraId) throws NotFoundException {
+        Activity activity = activityService.getActivity(lraId);
+
+        if (activity.getStatus() == null) {
+            throw new IllegalLRAStateException(lraId, "LRA is not active", "getStatus");
+        }
+
+        if (activity.getAndDecrementAcceptCount() <= 0) {
+            if (activity.getStatus() == CompensatorStatus.Completing) {
+                activity.setStatus(CompensatorStatus.Completed);
+            } else if (activity.getStatus() == CompensatorStatus.Compensating) {
+                activity.setStatus(CompensatorStatus.Compensated);
+            }
+        }
+
+        return Response.ok(activity.getStatus().name()).build();
+    }
+
+    @PUT
+    @Path("/complete")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Complete
+    @TimeLimit(limit = 100, unit = TimeUnit.MILLISECONDS)
+    public Response completeWork(@HeaderParam(LRAClient.LRA_HTTP_HEADER) String lraId, String userData) throws NotFoundException {
+        COMPLETED_COUNT.incrementAndGet();
+
+        assert lraId != null;
+
+        Activity activity = activityService.getActivity(lraId);
+
+        activity.setEndData(userData);
+
+        if (activity.getAndDecrementAcceptCount() > 0) {
+            activity.setStatus(CompensatorStatus.Completing);
+            activity.setStatusUrl(String.format("%s/%s/%s/status", context.getBaseUri(), ACTIVITIES_PATH2, lraId));
+
+            return Response.accepted().location(URI.create(activity.getStatusUrl())).build();
+        }
+
+        activity.setStatus(CompensatorStatus.Completed);
+        activity.setStatusUrl(String.format("%s/%s/activity/completed", context.getBaseUri(), lraId));
+
+        endCheck(activity);
+
+        System.out.printf("ActivityController completing %s%n", lraId);
+        return Response.ok(activity.getStatusUrl()).build();
+    }
+
+    @PUT
+    @Path("/compensate")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Compensate
+    @TimeLimit(limit = 100, unit = TimeUnit.MILLISECONDS)
+    public Response compensateWork(@HeaderParam(LRAClient.LRA_HTTP_HEADER) String lraId, String userData) throws NotFoundException {
+        COMPENSATED_COUNT.incrementAndGet();
+
+        assert lraId != null;
+
+        Activity activity = activityService.getActivity(lraId);
+
+        activity.setEndData(userData);
+
+        if (activity.getAndDecrementAcceptCount() > 0) {
+            activity.setStatus(CompensatorStatus.Compensating);
+            activity.setStatusUrl(String.format("%s/%s/%s/status", context.getBaseUri(), ACTIVITIES_PATH2, lraId));
+
+            return Response.accepted().location(URI.create(activity.getStatusUrl())).build();
+        }
+
+        activity.setStatus(CompensatorStatus.Compensated);
+        activity.setStatusUrl(String.format("%s/%s/activity/compensated", context.getBaseUri(), lraId));
+
+        endCheck(activity);
+
+        System.out.printf("ActivityController compensating %s%n", lraId);
+        return Response.ok(activity.getStatusUrl()).build();
+    }
+
+    @DELETE
+    @Path("/forget")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Forget
+    public Response forgetWork(@HeaderParam(LRAClient.LRA_HTTP_HEADER) String lraId) {
+        COMPLETED_COUNT.incrementAndGet();
+
+        assert lraId != null;
+
+        Activity activity = activityService.getActivity(lraId);
+
+        activityService.remove(activity.getId());
+        activity.setStatus(CompensatorStatus.Completed);
+        activity.setStatusUrl(String.format("%s/%s/activity/completed", context.getBaseUri(), lraId));
+
+        System.out.printf("ActivityController forgetting %s%n", lraId);
+        return Response.ok(activity.getStatusUrl()).build();
+    }
+
+    @PUT
+    @Path(ACCEPT_WORK)
+    @LRA(LRA.Type.REQUIRED)
+    public Response acceptWork(
+            @HeaderParam(LRAClient.LRA_HTTP_RECOVERY_HEADER) String rcvId,
+            @HeaderParam(LRAClient.LRA_HTTP_HEADER) String lraId) {
+        assert lraId != null;
+        Activity activity = addWork(lraId, rcvId);
+
+        if (activity == null) {
+            return Response.status(Response.Status.EXPECTATION_FAILED).entity("Missing lra data").build();
+        }
+
+        activity.setAcceptedCount(1); // tests that it is possible to asynchronously complete
+        return Response.ok(lraId).build();
+    }
+
+    @GET
+    @Path(ActivityController.COMPLETED_COUNT_RESOURCE_METHOD)
+    @Produces(MediaType.APPLICATION_JSON)
+    @LRA(LRA.Type.NOT_SUPPORTED)
+    public Response getCompleteCount() {
+        return Response.ok(COMPLETED_COUNT.get()).build();
+    }
+    @GET
+    @Path(ActivityController.COMPENSATED_COUNT_RESOURCE_METHOD)
+    @Produces(MediaType.APPLICATION_JSON)
+    @LRA(LRA.Type.NOT_SUPPORTED)
+    public Response getCompensatedCount() {
+        return Response.ok(COMPENSATED_COUNT.get()).build();
+    }
+
+    @GET
+    @Path("/timeLimitRequiredLRA")
+    @Produces(MediaType.APPLICATION_JSON)
+    @TimeLimit(limit = 100, unit = TimeUnit.MILLISECONDS)
+    @LRA(value = LRA.Type.REQUIRED)
+    public Response timeLimitRequiredLRA(@HeaderParam(LRAClient.LRA_HTTP_HEADER) String lraId) {
+        activityService.add(new Activity(lraId));
+
+        try {
+            Thread.sleep(300); // sleep for 200 miliseconds (should be longer than specified in the @TimeLimit annotation)
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        return Response.status(Response.Status.OK).entity(Entity.text("Simulate business logic timeoout")).build();
+    }
+
+    @GET
+    @Path(TIME_LIMIT_SUPPORTS_LRA)
+    @Produces(MediaType.APPLICATION_JSON)
+    @LRA(value = LRA.Type.SUPPORTS)
+    public Response timeLimitSupportsLRA(@HeaderParam(LRAClient.LRA_HTTP_HEADER) String lraId) {
+        activityService.add(new Activity(lraId));
+
+        return Response.status(Response.Status.OK).entity(Entity.text("Simulate business logic timeoout")).build();
+    }
+
+    private Activity addWork(String lraId, String rcvId) {
+        assert lraId != null;
+
+        System.out.printf("ActivityController: work id %s and rcvId %s %n", lraId, rcvId);
+
+        try {
+            return activityService.getActivity(lraId);
+        } catch (NotFoundException e) {
+            Activity activity = new Activity(lraId);
+
+            activity.setRcvUrl(rcvId);
+            activity.setStatus(null);
+
+            activityService.add(activity);
+
+            return activity;
+        }
+    }
+
+    private void endCheck(Activity activity) {
+        String how = activity.getHow();
+        String arg = activity.getArg();
+
+        activity.setHow(null);
+        activity.setArg(null);
+
+        if ("wait".equals(how) && arg != null && "recovery".equals(arg)) {
+            lraClient.getRecoveringLRAs();
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/service/ActivityService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/service/ActivityService.java
@@ -51,4 +51,10 @@ public class ActivityService {
     public void remove(String id) {
         activities.remove(id);
     }
+
+    public void remove(Activity activity) {
+        activity.cleanup();
+
+        remove(activity.getId());
+    }
 }


### PR DESCRIPTION
#6 This PR adds two TCK tests which validate that timeout values on LRA start requests and LRA join requests are respected. The tests are TckTests#timeLimitRequiredLRA and TckTests#participantTimeLimitSupportsLRA respectively.

Notice that the tests need to query the state of an active LRA testing for state CompensatorStatus#Compensating which was missing from the LRAInfo class. This PR therefore also updates the LRAInfo class to also report this state.