### PR TITLE
issue26 LRAClient::set * CoordinatorURI is implementation specific

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/lra/client/LRAClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/client/LRAClient.java
@@ -80,20 +80,6 @@ public interface LRAClient {
     String LRA_RECOVERY_PATH_KEY = "lra.coordinator.recovery.path";
 
     /**
-     * Set the endpoint on which the coordinator is available
-     *
-     * @param uri the url of the LRA coordinator
-     */
-    void setCoordinatorURI(URI uri);
-
-    /**
-     * Set the endpoint on which the recovery coordinator is available
-     *
-     * @param uri the url of the LRA recovery coordinator
-     */
-    void setRecoveryCoordinatorURI(URI uri);
-
-    /**
      * Explicitly dispose of all resources. After this call the instance may no
      * longer be useable
      */

--- a/tck/running_the_tck.asciidoc
+++ b/tck/running_the_tck.asciidoc
@@ -33,7 +33,7 @@ following dependency to your build:
 
 and then start a MicroProfile enabled container that scans this dependency for the JAX-RS resources
 that comrise the TCK. The TCK relies upon an instance of `org.eclipse.microprofile.lra.client.LRAClient`
-to be injected, via CDI, into the test suite. Your own dependencies should provide an implementation
+to be injected, via CDI, into the test suite. Your own dependencies should provide an already configured implementation
 of LRAClient that can be used by CDI to satisfy the injection point.
 
 With this set up, you may trigger the TCK by sending a PUT request to the path tck/all:

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
@@ -47,7 +47,6 @@ import java.util.stream.IntStream;
 
 import static org.eclipse.microprofile.lra.client.LRAClient.LRA_COORDINATOR_HOST_KEY;
 import static org.eclipse.microprofile.lra.client.LRAClient.LRA_COORDINATOR_PORT_KEY;
-import static org.eclipse.microprofile.lra.client.LRAClient.LRA_COORDINATOR_PATH_KEY;
 import static org.eclipse.microprofile.lra.client.LRAClient.LRA_RECOVERY_PATH_KEY;
 import static org.eclipse.microprofile.lra.tck.participant.api.ActivityController.ACCEPT_WORK;
 import static org.eclipse.microprofile.lra.tck.participant.api.ActivityController.ACTIVITIES_PATH;
@@ -118,12 +117,10 @@ public class TckTests {
             int servicePort = Integer.getInteger("service.http.port", TEST_SWARM_PORT);
             String rcHost = System.getProperty(LRA_COORDINATOR_HOST_KEY, "localhost");
             int rcPort = Integer.getInteger(LRA_COORDINATOR_PORT_KEY, COORDINATOR_SWARM_PORT);
-            String coordinatorPath = System.getProperty(LRA_COORDINATOR_PATH_KEY, "lra-coordinator");
 
             micrserviceBaseUrl = new URL(String.format("http://localhost:%d", servicePort));
             rcBaseUrl = new URL(String.format("http://%s:%d", rcHost, rcPort));
 
-            lraClient.setCoordinatorURI(new URI(String.format("http://%s:%d/%s", rcHost, rcPort, coordinatorPath)));
             msClient = ClientBuilder.newClient();
             rcClient = ClientBuilder.newClient();
 


### PR DESCRIPTION
issue #26

Signed-off-by: xstefank <xstefank122@gmail.com>

This PR also changes the TCK to require already configured instance of `LRAClient` interface