### PR TITLE
Fix StandardController default response media type

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/StandardController.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/StandardController.java
@@ -49,7 +49,7 @@ public class StandardController {
     public Response work2(@HeaderParam(LRA_HTTP_HEADER) String lraId) throws NotFoundException {
 
         if (lraId != null) {
-            return Response.status(Response.Status.PRECONDITION_FAILED).entity(Entity.text("Unexpected LRA context")).build();
+            return Response.status(Response.Status.PRECONDITION_FAILED).entity("Unexpected LRA context").build();
         }
 
         WebTarget resourcePath = ClientBuilder.newClient().target(context.getBaseUri())
@@ -61,7 +61,7 @@ public class StandardController {
         String id = checkStatusAndClose(response, Response.Status.OK.getStatusCode(), true, resourcePath);
 
         if (id == null) {
-            return Response.status(Response.Status.PRECONDITION_FAILED).entity(Entity.text("LRA context was not propagated")).build();
+            return Response.status(Response.Status.PRECONDITION_FAILED).entity("LRA context was not propagated").build();
         }
 
         return Response.ok(id).build();


### PR DESCRIPTION
StandardController returns an `Entity.text(...)` on error [1, 2]. Some frameworks, e.g. RestEasy, default response media type to `application/octet-stream` which in turn when the execution hits any of the above mentioned statements returns 

`Failed executing PUT /activities3/work: org.jboss.resteasy.core.NoMessageBodyWriterFoundFailure: Could not find MessageBodyWriter for response object of type: javax.ws.rs.client.Entity of media type: application/octet-stream`

[1] https://github.com/eclipse/microprofile-lra/blob/master/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/StandardController.java#L52
[2] https://github.com/eclipse/microprofile-lra/blob/master/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/StandardController.java#L64

Signed-off-by: xstefank <xstefank122@gmail.com>