### PR TITLE
Issue69  TCK test updates (for the LRA terminal attribute)

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckMethodResult.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckMethodResult.java
@@ -90,7 +90,7 @@ class TckMethodResult {
         } catch (Throwable t) {
             result = t.getMessage();
             passed = false;
-            System.out.printf("Test %s failed: %s%n", testName, result);
+            System.out.printf("Test %s failed: %s: %s%n", testName, t.getClass().getName(), result);
 
             if (verbose) {
                 t.printStackTrace(System.out);

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
@@ -310,13 +310,11 @@ public class TckTests {
 
         String nestedLraId = checkStatusAndClose(response, Response.Status.OK.getStatusCode(), true, resourcePath);
 
-        List<LRAInfo> lras = lraClient.getActiveLRAs();
-
         // close the LRA
         lraClient.closeLRA(lra);
 
         // validate that the nested LRA was closed
-        lras = lraClient.getActiveLRAs();
+        List<LRAInfo> lras = lraClient.getActiveLRAs();
 
         // the resource /activities/work is annotated with Type.REQUIRED so the container should have ended it
         assertNull(getLra(lras, nestedLraId), "nestedActivity: nested LRA should not be active", resourcePath);
@@ -749,14 +747,14 @@ public class TckTests {
                         resourcePath.getUri().toString(), e.getMessage()));
             }
         });
-        // check that the multiLevelNestedActivity method returned the mandatory LRA followed by two nested LRAs
+        // check that the multiLevelNestedActivity method returned the mandatory LRA followed by any nested LRAs
         assertEquals(nestedCnt + 1, lraArray.length, "multiLevelNestedActivity: step 1", resourcePath);
         assertEquals(lraId, lraArray[0], "multiLevelNestedActivity: step 2", resourcePath); // first element should be the mandatory LRA
 
         // check that the coordinator knows about the two nested LRAs started by the multiLevelNestedActivity method
         // NB even though they should have completed they are held in memory pending the enclosing LRA finishing
         IntStream.rangeClosed(1, nestedCnt).forEach(i -> assertNotNull(getLra(lras, lraArray[i]),
-                "missing nested LRA",
+                " missing nested LRA: step 2b",
                 resourcePath));
 
         // and the mandatory lra seen by the multiLevelNestedActivity method
@@ -764,7 +762,7 @@ public class TckTests {
 
         int[] cnt2 = {completedCount(true), completedCount(false)};
 
-        // check that both nested activities were told to complete
+        // check that all nested activities were told to complete
         assertEquals(cnt1[0] + nestedCnt, cnt2[0], "multiLevelNestedActivity: step 3", resourcePath);
         // and that neither were told to compensate
         assertEquals(cnt1[1], cnt2[1], "multiLevelNestedActivity: step 4", resourcePath);

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ActivityController.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ActivityController.java
@@ -71,7 +71,7 @@ import static org.eclipse.microprofile.lra.client.LRAClient.LRA_HTTP_RECOVERY_HE
 
 @ApplicationScoped
 @Path(ActivityController.ACTIVITIES_PATH)
-@LRA(LRA.Type.SUPPORTS)
+@LRA(value = LRA.Type.SUPPORTS, terminal = false)
 public class ActivityController {
     public static final String ACTIVITIES_PATH = "activities";
     public static final String ACCEPT_WORK = "acceptWork";
@@ -106,7 +106,7 @@ public class ActivityController {
     @Path("/status")
     @Produces(MediaType.APPLICATION_JSON)
     @Status
-    @LRA(LRA.Type.NOT_SUPPORTED)
+    @LRA(value = LRA.Type.NOT_SUPPORTED)
     public Response status(@HeaderParam(LRA_HTTP_HEADER) String lraId) throws NotFoundException {
         Activity activity = activityService.getActivity(lraId);
 
@@ -344,7 +344,7 @@ public class ActivityController {
 
     @PUT
     @Path(MANDATORY_LRA_RESOURCE_PATH)
-    @LRA(LRA.Type.MANDATORY)
+    @LRA(value = LRA.Type.MANDATORY, terminal = false)
     public Response activityWithMandatoryLRA(@HeaderParam(LRA_HTTP_RECOVERY_HEADER) String rcvId,
                                              @HeaderParam(LRA_HTTP_HEADER) String lraId) {
         return activityWithLRA(rcvId, lraId);
@@ -352,7 +352,7 @@ public class ActivityController {
 
     @PUT
     @Path("/nestedActivity")
-    @LRA(value = LRA.Type.MANDATORY, terminal = false)
+    @LRA(value = LRA.Type.MANDATORY, terminal = true)
     @NestedLRA
     public Response nestedActivity(@HeaderParam(LRA_HTTP_RECOVERY_HEADER) String rcvId,
                                    @HeaderParam(LRA_HTTP_HEADER) String nestedLRAId) {
@@ -467,7 +467,7 @@ public class ActivityController {
     @GET
     @Path("/timeLimit")
     @Produces(MediaType.APPLICATION_JSON)
-    @LRA(value = LRA.Type.REQUIRED, terminal = false, timeLimit = 100, timeUnit = ChronoUnit.MILLIS)
+    @LRA(value = LRA.Type.REQUIRED, timeLimit = 100, timeUnit = ChronoUnit.MILLIS)
     public Response timeLimit(@HeaderParam(LRA_HTTP_HEADER) String lraId) {
         assertHeaderPresent(lraId);
 


### PR DESCRIPTION
#69 

Issue #40 removed the delayClose attribute of the LRA annotation since it effectively duplicated the terminal attribute. The fix for that issue also changed the default behaviour for closing an LRA at the end of the method. But some of the TCK test resources methods were changed to have a different semantic (in particular the @lra annotation applied at class level provides did not specify the new attribute value).