### PR TITLE
issue83 Move LRAInfo into TCK

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/lra/client/LRAClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/client/LRAClient.java
@@ -21,7 +21,6 @@
 package org.eclipse.microprofile.lra.client;
 
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
-import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
 
 import javax.ws.rs.NotFoundException;
 import java.net.URI;

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/LRAInfo.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/LRAInfo.java
@@ -18,7 +18,7 @@
  * limitations under the License.
  *******************************************************************************/
 
-package org.eclipse.microprofile.lra.client;
+package org.eclipse.microprofile.lra.tck;
 
 /**
  * Data object carrying information about an instance

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
@@ -22,7 +22,6 @@ package org.eclipse.microprofile.lra.tck;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.client.GenericLRAException;
 import org.eclipse.microprofile.lra.client.LRAClient;
-import org.eclipse.microprofile.lra.client.LRAInfo;
 import org.eclipse.microprofile.lra.tck.spi.ManagementSPI;
 import org.eclipse.microprofile.lra.tck.participant.api.StandardController;
 import org.junit.After;

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/spi/ManagementSPI.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/spi/ManagementSPI.java
@@ -20,7 +20,7 @@
 package org.eclipse.microprofile.lra.tck.spi;
 
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
-import org.eclipse.microprofile.lra.client.LRAInfo;
+import org.eclipse.microprofile.lra.tck.LRAInfo;
 
 import javax.ws.rs.NotFoundException;
 import java.net.URL;


### PR DESCRIPTION
Fixes issue #83 
The class LRAInfo is only ever used by the TCK so it should be moved into that module

The fix also fixes a checkstyle issue for an unused import in LRAClient that was introduced in PR #82 