### PR TITLE
[issue59] after getAll method moved to TCK

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/lra/client/LRAClient.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/client/LRAClient.java
@@ -21,7 +21,6 @@
 package org.eclipse.microprofile.lra.client;
 
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
-import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
 
 import javax.ws.rs.NotFoundException;
 import java.net.URI;


### PR DESCRIPTION
 there is no need for this import which causes checkstyle violation

https://github.com/eclipse/microprofile-lra/pull/82

/cc @mmusgrov 