### PR TITLE
Removing getStatus method from ManagementSPI as it's duplicate of one in LRAClient

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
@@ -247,7 +247,7 @@ public class TckTests {
     private String isActiveLRA() throws WebApplicationException {
         URL lra = lraClient.startLRA(null, "SpecTest#isActiveLRA", LRA_TIMEOUT_MILLIS, ChronoUnit.MILLIS);
 
-        assertTrue(lraSPI.getStatus(lra).isActive(), null, null, lra);
+        assertTrue(lraClient.getStatus(lra) == LRAStatus.Active, null, null, lra);
 
         lraClient.closeLRA(lra);
 
@@ -261,7 +261,7 @@ public class TckTests {
 
         lraClient.cancelLRA(lra);
 
-        assertTrue(lraSPI.getStatus(lra).isCompensated(), null, null, lra);
+        assertTrue(lraClient.getStatus(lra) == LRAStatus.Cancelled, null, null, lra);
 
         return lra.toExternalForm();
     }
@@ -273,7 +273,7 @@ public class TckTests {
 
         lraClient.closeLRA(lra);
 
-        assertTrue(lraSPI.getStatus(lra).isComplete(), null, null, lra);
+        assertTrue(lraClient.getStatus(lra) == LRAStatus.Closed, null, null, lra);
 
         return lra.toExternalForm();
     }
@@ -864,7 +864,7 @@ public class TckTests {
             assertEquals(cnt1[1] + 1, cnt2[1], "compensate should have been called", resourcePath);
 
             try {
-                assertTrue(!lraSPI.getStatus(lra).isActive(), "cancelCheck: LRA should have been cancelled", resourcePath, lra);
+                assertTrue(lraClient.getStatus(lra) != LRAStatus.Active, "cancelCheck: LRA should have been cancelled", resourcePath, lra);
             } catch (NotFoundException ignore) {
                 // means the LRA has gone
             }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/spi/ManagementSPI.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/spi/ManagementSPI.java
@@ -22,23 +22,13 @@ package org.eclipse.microprofile.lra.tck.spi;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.tck.LRAInfo;
 
-import javax.ws.rs.NotFoundException;
-import java.net.URL;
 import java.util.List;
 
+/**
+ * This is interface expected to be implemented by TCK implementor.
+ * The interface contains methods used in the TCK suite.
+ */
 public interface ManagementSPI {
-    /**
-     * Lookup information about an LRA
-     *
-     * @param lraId the LRA whose status is being requested
-     *
-     * @return the status of the the LRA
-     *
-     * @throws NotFoundException if the LRA no longer exists (which may or may
-     * not indicate that the LRA has already closed or cancelled depending upon
-     * how long the implementation chooses to maintain such information).
-     */
-    LRAInfo getStatus(URL lraId) throws NotFoundException;
 
     /**
      * Lookup LRAs that are in a particular state.


### PR DESCRIPTION
Creating PR as follow-up to https://github.com/eclipse/microprofile-lra/pull/82 as there is duplicate method at spi and `LRAClient`.