### PR TITLE
Issue94 tck arq refactoring next fixes

### DIFF
--- a/spec/src/main/asciidoc/microprofile-lra-spec.adoc
+++ b/spec/src/main/asciidoc/microprofile-lra-spec.adoc
@@ -289,8 +289,9 @@ annotated with `@Compensate` and `@Complete` then these methods will be associat
 the active LRA. They will be invoked when the LRA is subsequently cancelled or closed.
 If the participant successfully compensates or completes then it may forget about the LRA.
 Otherwise it should remember that it is still associated with the LRA and it MUST report
-the status of the association using values in the `ParticipantStatus` enum according to
-the participant state model defined earlier.
+the status of the association using values in the
+https://github.com/eclipse/microprofile-lra/tree/master/api/src/main/java/org/eclipse/microprofile/lra/annotation/ParticipantStatus.java[`ParticipantStatus`]
+enum according to the participant state model defined earlier.
 It can report the status directly from the `@Compensate` or `@Complete` methods if they
 are idempotent, otherwise it MUST provide a method annotated with `@Status`.
 

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/LRAInfo.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/LRAInfo.java
@@ -22,42 +22,42 @@ package org.eclipse.microprofile.lra.tck;
 
 /**
  * Data object carrying information about an instance
- * of LRA (specified by lra id) and it's status.
+ * of LRA (specified by LRA id) and it's status.
  */
 public interface LRAInfo {
 
     /**
-     * @return  lra id that lra instance is identified by
+     * @return  LRA id that LRA instance is identified by
      */
     String getLraId();
 
     /**
-     * @return  lra client id
+     * @return  LRA client id
      */
     String getClientId();
 
     /**
-     * @return  true if lra was successfully completed, false otherwise
+     * @return  true if LRA was successfully closed, false otherwise
      */
-    boolean isComplete();
+    boolean isClosed();
 
     /**
-     * @return  true if lra was compensated, false otherwise
+     * @return  true if LRA was cancelled, false otherwise
      */
-    boolean isCompensated();
+    boolean isCancelled();
 
     /**
-     * @return  true if recovery is in progress on the lra, false otherwise
+     * @return  true if recovery is in progress on the LRA, false otherwise
      */
     boolean isRecovering();
 
     /**
-     * @return  true if lra is in active state right now, false otherwise
+     * @return  true if LRA is in active state right now, false otherwise
      */
     boolean isActive();
 
     /**
-     * @return  true if lra is top level (not nested), false otherwise
+     * @return  true if LRA is top level (not nested), false otherwise
      */
     boolean isTopLevel();
 }


### PR DESCRIPTION
#94

this is a follow-up for the #87

I found the `LRAStatus` was changed for `cancel` and `closed` and as the `LRAInfo` gathers information about the `LRAStatus` the method names should follow this naming