### PR TITLE
issue139 Remove references to recovery coordinators

### DIFF
--- a/spec/src/main/asciidoc/microprofile-lra-spec.adoc
+++ b/spec/src/main/asciidoc/microprofile-lra-spec.adoc
@@ -370,6 +370,9 @@ for recovery purposes and it should make it available to the participant via a J
 header param with name defined by the Java constant `LRA_HTTP_RECOVERY_HEADER` as defined
 <<source-LRA, in the LRA annotation>>
 (https://github.com/eclipse/microprofile-lra/tree/master/api/src/main/java/org/eclipse/microprofile/lra/annotation/LRA.java[github link]).
+This recovery header should be made available to the application whenever any
+of the participant callbacks are invoked. The application is free to ignore
+this header.
 Enlisting in an LRA is explained in more detail
 <<compensating-activities,in a later section>> of this document.
 
@@ -790,9 +793,9 @@ public class UnannotatedParticpant implements LRAParticipant {
 The framework must guarantee that participants will still be triggered (the LRA protocol still provides the "all or
 nothing" guarantees that traditional transactions give).
 This means that an implementation for all JAX-RS resources which implement the _LRAParticipant_ interface directly
-or indirectly, MUST create some proxy which can be called by the coordinator. +
+or indirectly, MUST create some proxy which can be called by the spec implementation. +
 This to ensure that after this class has joined an LRA (through the _lraManagement.joinLRA()_ ) the _complete_ or
-_compensate_ methods can be called by the coordinator in case the microservice crashed before this notification could
+_compensate_ methods can be called by the spec implementation in case the microservice crashed before this notification could
 be delivered.
 
 Serializable participants need to know how to contact the original

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/LraTckConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/LraTckConfigBean.java
@@ -49,26 +49,29 @@ public class LraTckConfigBean {
     private double timeoutFactor;
 
     /**
-     * Host name where LRA recovery is expected to be launch and TCK suite tries to connect to it at.
-     * The port is specifed by {@link #recoveryPort}.
+     * <p>
+     *     the maximum number of seconds to wait for recovery
+     * </p>
      */
-    @Inject @ConfigProperty(name = LRAClientOps.LRA_RECOVERY_HOST_KEY, defaultValue = "localhost")
-    private String recoveryHostName;
+    @Inject @ConfigProperty(name = "lra.tck.recovery.timeout", defaultValue = "200")
+    private long recoveryTimeout;
 
     /**
-     * Port where LRA recovery is expected to be launch and TCK suite tries to connect to it at.
-     * The hostname is specifed by {@link #recoveryHostName}.
+     * If true then the TCK should use the recovery header to give a hint to the implementation
+     * under test that it should replay the LRA protocol termination phase ie to call the
+     * compensate/complete callback on target resource (if the resource is also an LRA participant
+     * and is in need of recovery).
+     *
+     * See the method {@link TckTestBase#replayEndPhase} for how/where it is used. The replayEndPhase
+     * method will keep waiting for recovery until either recovery has been triggered or until
+     * {@link #recoveryTimeout} seconds have elapsed.
+     *
+     * Implementations that do not support triggering recovery should ensure that the
+     * {@link #recoveryTimeout} value is set to a value that is longer than the implementations
+     * typical recovery period.
      */
-    @Inject @ConfigProperty(name = LRAClientOps.LRA_RECOVERY_PORT_KEY, defaultValue = "8080")
-    private int recoveryPort;
-
-    /**
-     * Path where recovery is available to accept requests.
-     * The hostname of LRA recovery is specifed by {@link #recoveryHostName},
-     * the port of LRA recovery is defined by {@link #recoveryPort}.
-     */
-    @Inject @ConfigProperty(name = LRAClientOps.LRA_RECOVERY_PATH_KEY, defaultValue = "lra-recovery-coordinator")
-    private String recoveryPath;
+    @Inject @ConfigProperty(name = "lra.tck.recovery.trigger", defaultValue = "true")
+    private boolean useRecoveryHeader;
 
     /**
      * Base URL where the LRA suite is started at. It's URL where container exposes the test suite deployment.
@@ -84,16 +87,12 @@ public class LraTckConfigBean {
         return timeoutFactor;
     }
 
-    public String recoveryHostName() {
-        return recoveryHostName;
+    public Long recoveryTimeout() {
+        return recoveryTimeout;
     }
 
-    public int recoveryPort() {
-        return recoveryPort;
-    }
-
-    public String recoveryPath() {
-        return recoveryPath;
+    public boolean isUseRecoveryHeader() {
+        return useRecoveryHeader;
     }
 
     public String tckSuiteBaseUrl() {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
@@ -85,7 +85,7 @@ public class TckContextTests extends TckTestBase {
     }
 
     @Test
-    public void testStatus() {
+    public void testStatus() throws InterruptedException {
         // call a resource that begins and ends an LRA and coerces the resource to return ACCEPTED when asked to complete
         String lra = invoke(REQUIRED_LRA_PATH, PUT, null, 200, ContextTckResource.EndPhase.ACCEPTED, 202);
 
@@ -128,7 +128,7 @@ public class TckContextTests extends TckTestBase {
     }
 
     @Test
-    public void testForget() {
+    public void testForget() throws InterruptedException {
         String count;
         // call a resource that begins and ends an LRA and coerces the resource to return FAILED when asked to complete
         String lra = invoke(REQUIRED_LRA_PATH, PUT, null, 200, ContextTckResource.EndPhase.FAILED, 500);


### PR DESCRIPTION
#139 

This PR removes references to recovery coordinators. In particular, the tests that triggered a recovery scan have been replaced by a blocking wait for a configurable period (see property lra.tck.recovery.timeout below). The default is 200 seconds which is appropriate to the implementation that I tested against and if the period elapses without recovery having taken place then the test is marked as failed. Let me know if this default is too short.

I did include a hint in LraTckConfigBean#useRecoveryHeader that implementations are free to use if they want to provide more timely recovery.