### PR TITLE
Fix +1 problem in replayEndPhase

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ParticipatingTckResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ParticipatingTckResource.java
@@ -90,9 +90,7 @@ public class ParticipatingTckResource {
     }
 
     private Response getEndPhaseResponse(boolean complete) {
-        if (recoveryPasses > 0) {
-            recoveryPasses -= 1;
-
+        if (--recoveryPasses > 0) {
             return Response.accepted().build();
         }
 


### PR DESCRIPTION
replayEndPhase method is calling this resource for querying whether recovery has happened. It initializes recoveryPasses to 2 (see [this](https://github.com/eclipse/microprofile-lra/blob/master/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTestBase.java#L167)) and expects that this value will be decremented two times. However, the current version of the spec first checks the value and then decrements it which results into this newly stared LRA being not finished by the end of the test. Typically it is finished by the next test that does replayEndPhase again but that leaves the newly started LRA not finished and so on. This means that at the end of the TCK there is at least one LRA hanging in Cancelling or Completing state.