### PR TITLE
issue164 Support notifications that an LRA has finished

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/lra/annotation/AfterLRA.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/annotation/AfterLRA.java
@@ -1,0 +1,82 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.lra.annotation;
+
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * If a JAX-RS resource method is annotated with
+ * {@link LRA} and is invoked in the context of an LRA then
+ * the resource can ask to be notified when the LRA finishes
+ * by marking one of the other methods in the class with
+ * the {@link AfterLRA} annotation.
+ * </p>
+ *
+ * <p>
+ * If the <code>AfterLRA</code> method is also a JAX-RS resource method
+ * then the LRA context is made available to the annotated method
+ * via an HTTP header with the name
+ * {@link LRA#LRA_HTTP_ENDED_CONTEXT_HEADER} and the
+ * final status is passed to the method as plain text
+ * corresponding to one of the {@link LRAStatus} enum values.
+ * For example:
+ * <pre>
+ *     <code>
+ * @PUT
+ * @AfterLRA
+ * public Response afterEnd(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId,
+ *                          LRAStatus status)
+ *     </code>
+ * </pre>
+ * </p>
+ *
+ * <p>
+ * The implementation will keep resending the notification
+ * until it receives a <code>200 OK</code> status code from the
+ * resource method (which means that the method SHOULD be
+ * idempotent).
+ * </p>
+ *
+ * <p>
+ * If the <code>AfterLRA</code> method is not a JAX-RS resource method
+ * then the id of the LRA and its final status can be obtained
+ * by ensuring that the annotated method conforms to the
+ * signature:
+ *
+ * <code>
+ *     public void onLRAEnd(URI lraId, LRAStatus status)
+ * </code>
+ *
+ * </p>
+ * <p>
+ * The return type is ignored and the method name is not
+ * significant.
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface AfterLRA {
+}

--- a/api/src/main/java/org/eclipse/microprofile/lra/annotation/ws/rs/LRA.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/annotation/ws/rs/LRA.java
@@ -23,6 +23,7 @@ package org.eclipse.microprofile.lra.annotation.ws.rs;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.core.Response;
 
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
 import org.eclipse.microprofile.lra.annotation.Compensate;
 import org.eclipse.microprofile.lra.annotation.Complete;
 import org.eclipse.microprofile.lra.annotation.Forget;
@@ -102,6 +103,12 @@ public @interface LRA {
     String LRA_HTTP_CONTEXT_HEADER = "Long-Running-Action";
 
     /**
+     * Header name holding the LRA context of an LRA that has finished - to be
+     * used in conjunction with the {@link AfterLRA} annotation.
+     */
+    String LRA_HTTP_ENDED_CONTEXT_HEADER = "Long-Running-Action-Ended";
+
+    /**
      * When a JAX-RS invocation is made with an active LRA which is nested,
      * the parent LRA is made available via an HTTP header field with the
      * following name. The value contains the parent LRA id associated with
@@ -132,6 +139,12 @@ public @interface LRA {
      *     but it does guarantee that they will eventually be sent. Under failure
      *     conditions the system will keep retrying until it is certain that all
      *     participants have been successfully notified.
+     * </p>
+     *
+     * <p>
+     *     If the method is to run in the context of an LRA and the annotated class
+     *     also contains a method annotated with {@link AfterLRA}
+     *     then the resource will be notified of the final state of the LRA.
      * </p>
      *
      * <p>

--- a/spec/src/main/asciidoc/microprofile-lra-spec.adoc
+++ b/spec/src/main/asciidoc/microprofile-lra-spec.adoc
@@ -501,6 +501,52 @@ The `end = false` element on the bookTrip method forces the LRA to continue runn
 the method finishes and the `end = true` element on the confirmTrip method forces the LRA
 (started by the bookTrip method) to close the LRA.
 
+[[after-lra]]
+===== Discovering the Outcome of an LRA
+
+As remarked in the previous section, a JAX-RS resource method runs with an active
+context depending upon the value specified in the `@LRA` annotation.
+The final state of this LRA can be discovered by marking one of the other methods
+in the class with the `@AfterLRA` annotation. When the LRA enters a terminal state
+the method will be passed the id of the LRA together with the `LRAStatus` (see the
+javadoc for the `@AfterLRA` annotation for more information). Note that the final
+states of an LRA is defined by <<lra-state-model,the LRA state model>> and it
+would be a specification violation if the implementation calls the method when the
+LRA is not in a final state. Further information about method signatures and
+JAX-RS response codes is given below in section <<jaxrs-participant-methods>>.
+
+Note that the resource does not need to be a participant in order to receive this
+notification. Therefore in the following resource definition, although no method
+is annotated with `@Compensate`, if the method called
+`activityWithLRA` is invoked then the method `notifyLRAFinished` will be called
+when the LRA finishes:
+
+[source,java]
+----
+public class BusinessResource {
+    @PUT
+    @Path("/work")
+    @LRA(value = LRA.Type.REQUIRES_NEW)
+    public Response activityWithLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        // perform a business action in the context of lraId
+        return Response.ok().build();
+    }
+
+    @PUT
+    @Path("/after")
+    @AfterLRA // method is called when the LRA associated with the method activityWithLRA finishes
+    public Response notifyLRAFinished(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId,
+                                      LRAStatus status) {
+
+        switch (status) {
+            case Closed:
+                // the LRA was successfully closed
+            ...    
+        }
+    }
+}
+----
+
 [[compensating-activities]]
 ==== Compensating Activities
 
@@ -545,7 +591,7 @@ If a compensating activity is brief then the synchronous model may be appropriat
 
 On the other hand, the compensating logic may involve concerted activities,
 perhaps even compensating in the context of another LRA. In this case the
-protocol accomodates a more decoupled mode of operation - the following example
+protocol accommodates a more decoupled mode of operation - the following example
 shows how a compensating activity can be started in the background:
 
 [source,java]
@@ -689,7 +735,7 @@ the participant state model>>. These annotations are:
 * `@Compensate` -- a method to be executed when the LRA is cancelled
 * `@Complete` -- a method to be executed when the LRA is closed
 * `@Status` -- a method that allow user to state status of the participant with regards 
-to a paricular LRA
+to a particular LRA
 * `@Forget` -- a method to be executed when the LRA allows participant to 
 clear all associated information
 
@@ -698,9 +744,9 @@ methods associated with the JAX-RS resource method or the methods which are not
 bound to JAX-RS. 
 
 [[jaxrs-participant-methods]]
-===== JAX-RS participant methods
+===== JAX-RS methods
 
-The following table presents expectations that are placed on individual participant 
+The following table presents expectations that are placed on individual
 annotations when associated with JAX-RS resource methods:
 
 [[jaxrs-response-table]]
@@ -727,22 +773,50 @@ annotations when associated with JAX-RS resource methods:
 | 200, 404, 412
 | no expectations
 
+| `@AfterLRA`
+| PUT
+| 200
+| no expectations
+
 |=== 
 
-The presented HTTP methods SHOULD be applied at individual JAX-RS participant methods 
+The presented HTTP methods SHOULD be applied at individual JAX-RS methods
 but they are not enforced by the specification. 
 
-If the annotated method returns an unexpected HTTP status code the implementation MAY
-invoke the same method again.
+If the method annotated with `@AfterLRA` returns an unexpected HTTP status
+or never reaches the caller then the implementation MUST invoke the same method again.
 
-Users are allowed to reuse existing JAX-RS endpoints for participant methods definitions. 
+If the annotated method returns an unexpected HTTP status code the implementation MAY
+invoke the same method again with the following caveat: if there is no `@Status` method
+and the implementation receives an unexpected response code from either of the
+`@Compensate` or `@Complete` invocations then it MUST reinvoke the method. [Note that
+this caveat applies to the situation where the response is lost since the caller will
+not see the correct code].
+
+Users are allowed to reuse existing JAX-RS endpoints for participant methods definitions.
 In this case, LRA implementation MUST ensure that invoking these methods outside of the 
 implementation of the LRA specification will not influence any running LRA.
+
+===== Non-JAX-RS afterLRA method
+
+A method annotated with `@AfterLRA` that is not a JAX-RS resource method MUST accept
+two arguments of type URI and LRAStatus, in that order. The first parameter holds
+an LRA context and the second parameter holds the final status of the LRA. If the
+signature does not conform to this requirement then the behaviour of the implementation
+is unspecified.
+
+An example of a valid signature is:
+
+[source,java]
+----
+@AfterLRA
+public void onLRAEnd(URI lraId, LRAStatus status)
+----
 
 [[non-jaxrs-participant-methods]]
 ===== Non-JAX-RS participant methods
 
-When the participant annotations are applied to the non-JAX-RS resource methods they 
+When the participant annotations are applied to the non-JAX-RS resource methods they
 MUST adhere to these predefined signatures:
 
 * *Return type*: 
@@ -1043,8 +1117,8 @@ participant compensation handlers to run:
 
         final CompletableFuture<Response> response = new CompletableFuture<>();
 
-        excecutorService.submit(() -> {
-            // excecute long running business activity finishing with a NOT_FOUND error
+        executorService.submit(() -> {
+            // execute long running business activity finishing with a NOT_FOUND error
             // which causes the LRA to cancel
             response.completeExceptionally(
                     new WebApplicationException(
@@ -1067,8 +1141,8 @@ the JAX-RS `@Suspended` annotation:
     @POST
     public void asyncResponseLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
                          final @Suspended AsyncResponse ar) {
-        excecutorService.submit(() -> {
-            // excecute long running business activity and resume when done
+        executorService.submit(() -> {
+            // execute long running business activity and resume when done
             ar.resume(Response.ok().entity(lraId).build());
         });
     }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/LRAClientOps.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/LRAClientOps.java
@@ -19,8 +19,11 @@
  *******************************************************************************/
 package org.eclipse.microprofile.lra.tck;
 
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
 import org.eclipse.microprofile.lra.tck.participant.api.GenericLRAException;
+import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
+import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation;
@@ -80,6 +83,42 @@ public class LRAClientOps {
         int status = tryToEnlistWithAnLRA(lra);
 
         return status == Response.Status.NOT_FOUND.getStatusCode() || status == Response.Status.PRECONDITION_FAILED.getStatusCode();
+    }
+
+    /**
+     * TODO if the current PR is acceptable then delete the old isLRAFinished method
+     * (which tests whether an LRA is active by making an attempt to enlist with it
+     * which some spec implementations report as a stack trace WARNING if the LRA is
+     * no longer active).
+     *
+     * @param lra the LRA to test
+     * @param lraMetricService metrics
+     * @param resourceName name of the resource that the metrics parameter applies to
+     * @return whether or not an LRA has finished
+     */
+    boolean isLRAFinished(URI lra, LRAMetricService lraMetricService, String resourceName) {
+        return getLRAEndStatus(lra, lraMetricService, resourceName) != null;
+    }
+
+    /**
+     *
+     * @param lra the LRA whose end status is being queried
+     * @param lraMetricService the metrics service
+     * @param resourceName the name of the resource whose metrics hold the end state of the LRA
+     * @return the end status of the LRA (or null if the LRA has not yet finished)
+     */
+    private LRAStatus getLRAEndStatus(URI lra, LRAMetricService lraMetricService, String resourceName) {
+        if (lraMetricService.getMetric(LRAMetricType.Closed, lra, resourceName) == 1) {
+            return LRAStatus.Closed;
+        } else if (lraMetricService.getMetric(LRAMetricType.FailedToClose, lra, resourceName) == 1) {
+            return LRAStatus.FailedToClose;
+        } else if (lraMetricService.getMetric(LRAMetricType.Cancelled, lra, resourceName) == 1) {
+            return LRAStatus.Cancelled;
+        } else if (lraMetricService.getMetric(LRAMetricType.FailedToCancel, lra, resourceName) == 1) {
+            return LRAStatus.FailedToCancel;
+        }
+
+        return null;
     }
 
     // synchronize access to the connection since it is shared with the LRA background cancellation code

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckCancelOnTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckCancelOnTests.java
@@ -66,9 +66,9 @@ public class TckCancelOnTests extends TckTestBase {
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.BAD_REQUEST, response, resourcePath));
         applyConsistencyDelay();
         assertEquals("After 400 compensate should be invoked", 
-            1, lraMetricService.getMetric(LRAMetricType.COMPENSATE, lraId));
+            1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("After 400 complete can't be invoked", 
-            0, lraMetricService.getMetric(LRAMetricType.COMPLETE, lraId));
+            0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }
 
     /**
@@ -84,9 +84,9 @@ public class TckCancelOnTests extends TckTestBase {
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.INTERNAL_SERVER_ERROR, response, resourcePath));
         applyConsistencyDelay();
         assertEquals("After 500 compensate should be invoked", 
-            1, lraMetricService.getMetric(LRAMetricType.COMPENSATE, lraId));
+            1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("After 500 complete can't be invoked", 
-            0, lraMetricService.getMetric(LRAMetricType.COMPLETE, lraId));
+            0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }
 
     /**
@@ -102,9 +102,9 @@ public class TckCancelOnTests extends TckTestBase {
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.SEE_OTHER, response, resourcePath));
         applyConsistencyDelay();
         assertEquals("After status code 303 is received, compensate should be invoked as set by attribute cancelOnFamily",
-                1, lraMetricService.getMetric(LRAMetricType.COMPENSATE, lraId));
+                1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("After status code 303 is received, complete can't be invoked as not defined in annotation @LRA",
-                0, lraMetricService.getMetric(LRAMetricType.COMPLETE, lraId));
+                0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }
 
     /**
@@ -120,9 +120,9 @@ public class TckCancelOnTests extends TckTestBase {
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.MOVED_PERMANENTLY, response, resourcePath));
         applyConsistencyDelay();
         assertEquals("After status code 301 is received, compensate should be invoked as set by attribute cancelOn",
-                1, lraMetricService.getMetric(LRAMetricType.COMPENSATE, lraId));
+                1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("After status code 301 is received, complete can't be invoked as not defined in annotation @LRA",
-                0, lraMetricService.getMetric(LRAMetricType.COMPLETE, lraId));
+                0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }
 
     /**
@@ -138,9 +138,9 @@ public class TckCancelOnTests extends TckTestBase {
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.INTERNAL_SERVER_ERROR, response, resourcePath));
         applyConsistencyDelay();
         assertEquals("After status code 500 is received, compensate can't be invoked as default behaviour was changed",
-                0, lraMetricService.getMetric(LRAMetricType.COMPENSATE, lraId));
+                0, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("After status code 500 is received, complete has to be called as default behaviour was changed",
-                1, lraMetricService.getMetric(LRAMetricType.COMPLETE, lraId));
+                1, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }
 
     /**
@@ -157,8 +157,8 @@ public class TckCancelOnTests extends TckTestBase {
         applyConsistencyDelay();
         // LraCancelOnController enlists twice the same participant, compensate is expected to be called only once
         assertEquals("Status was 200 but compensate should be called as LRA should be cancelled for remotely called participant as well",
-                1, lraMetricService.getMetric(LRAMetricType.COMPENSATE, lraId));
+                1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("Even the 200 status was received the remotely called participant should cause the LRA being cancelled",
-                0, lraMetricService.getMetric(LRAMetricType.COMPLETE, lraId));
+                0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
@@ -88,7 +88,7 @@ public class TckContextTests extends TckTestBase {
         invoke(false, REQUIRED_LRA_PATH, PUT, lra, 200, ContextTckResource.EndPhase.SUCCESS, 200);
 
         // verify that the resource was asked to complete
-        int completions = lraMetricService.getMetric(LRAMetricType.COMPLETE, lra);
+        int completions = lraMetricService.getMetric(LRAMetricType.Completed, lra);
 
         assertEquals(testName.getMethodName() + ": Resource was not asked to complete", 
                 1, completions);
@@ -130,7 +130,7 @@ public class TckContextTests extends TckTestBase {
         lraClient.closeLRA(lra);
 
         // verify that the resource was not asked to complete
-        int completions = lraMetricService.getMetric(LRAMetricType.COMPLETE, lra);
+        int completions = lraMetricService.getMetric(LRAMetricType.Completed, lra);
 
         assertEquals(testName.getMethodName() + ": Resource left but was still asked to complete",
                 0, completions);
@@ -146,11 +146,11 @@ public class TckContextTests extends TckTestBase {
         replayEndPhase(TCK_CONTEXT_RESOURCE_PATH);
 
         // the implementation should have called status which will have returned 500
-        count = lraMetricService.getMetric(LRAMetricType.STATUS, lra);
+        count = lraMetricService.getMetric(LRAMetricType.Status, lra);
         assertEquals(testName.getMethodName() + " resource status should have been called", 1, count);
 
         // the implementation should not call forget until it knows the participant status
-        count = lraMetricService.getMetric(LRAMetricType.FORGET, lra);
+        count = lraMetricService.getMetric(LRAMetricType.Forget, lra);
         assertEquals(testName.getMethodName() + " resource forget should not have been called", 0, count);
 
         // clear the fault
@@ -160,12 +160,12 @@ public class TckContextTests extends TckTestBase {
         replayEndPhase(TCK_CONTEXT_RESOURCE_PATH);
 
         // the implementation should have called status again which will have returned 200
-        count = lraMetricService.getMetric(LRAMetricType.STATUS, lra);
+        count = lraMetricService.getMetric(LRAMetricType.Status, lra);
         // the implementation should have called status at least once. Since we have alread called status in this test
         // check that the stat is at least 2
         assertTrue(testName.getMethodName() + " resource status should have been called again", count >= 2);
         // the implementation should call forget since it knows the participant status
-        count = lraMetricService.getMetric(LRAMetricType.FORGET, lra);
+        count = lraMetricService.getMetric(LRAMetricType.Forget, lra);
         assertEquals(testName.getMethodName() + " resource forget should have been called", 1, count);
     }
 
@@ -192,16 +192,16 @@ public class TckContextTests extends TckTestBase {
         // check that the resource was asked to complete twice, one in the context of the nested LRA and a
         // second time in the context of the top level LRA
 
-        int nestedCompletions = lraMetricService.getMetric(LRAMetricType.COMPLETE, nestedLRA);
+        int nestedCompletions = lraMetricService.getMetric(LRAMetricType.Completed, nestedLRA);
         assertEquals(testName.getMethodName() + ": resource should have completed for the nested LRA",
                 1, nestedCompletions);
 
-        int topLevelCompletions = lraMetricService.getMetric(LRAMetricType.COMPLETE, topLevelLRA);
+        int topLevelCompletions = lraMetricService.getMetric(LRAMetricType.Completed, topLevelLRA);
         assertEquals(testName.getMethodName() + ": resource should have completed for the top level LRA",
                 1, topLevelCompletions);
 
         // and validate that the parent LRA header was present when the nested LRA was asked to complete
-        int endCallsWithParentContextHeaderPresent = lraMetricService.getMetric(LRAMetricType.NESTED, topLevelLRA);
+        int endCallsWithParentContextHeaderPresent = lraMetricService.getMetric(LRAMetricType.Nested, topLevelLRA);
         assertEquals(testName.getMethodName() +
                         ": when the resource was asked to complete a nested LRA the parent context header was missing",
                 1, endCallsWithParentContextHeaderPresent);
@@ -219,7 +219,7 @@ public class TckContextTests extends TckTestBase {
         URI lra = URI.create(invoke(false, ASYNC_LRA_PATH1, PUT, null));
 
         // verify that the resource was asked to complete
-        int completions = lraMetricService.getMetric(LRAMetricType.COMPLETE, lra);
+        int completions = lraMetricService.getMetric(LRAMetricType.Completed, lra);
 
         assertEquals(testName.getMethodName() + ": Resource was not asked to complete",
                 1, completions);
@@ -230,7 +230,7 @@ public class TckContextTests extends TckTestBase {
         URI lra = URI.create(invoke(false, ASYNC_LRA_PATH2, PUT, null));
 
         // verify that the resource was asked to complete
-        int completions = lraMetricService.getMetric(LRAMetricType.COMPLETE, lra);
+        int completions = lraMetricService.getMetric(LRAMetricType.Completed, lra);
 
         assertEquals(testName.getMethodName() + ": Resource was not asked to complete",
                 1, completions);
@@ -243,8 +243,8 @@ public class TckContextTests extends TckTestBase {
             ContextTckResource.EndPhase.SUCCESS, 200));
 
         // verify that the resource was asked to compensate
-        int completions = lraMetricService.getMetric(LRAMetricType.COMPLETE, lra);
-        int compensations = lraMetricService.getMetric(LRAMetricType.COMPENSATE, lra);
+        int completions = lraMetricService.getMetric(LRAMetricType.Completed, lra);
+        int compensations = lraMetricService.getMetric(LRAMetricType.Compensated, lra);
 
         assertEquals(testName.getMethodName() + ": Resource was asked to complete",
                 0, completions);

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/AfterLRAListener.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/AfterLRAListener.java
@@ -1,0 +1,85 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.lra.tck.participant.api;
+
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
+import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_RECOVERY_HEADER;
+
+/**
+ * resource for testing that methods annotated with
+ * {@link AfterLRA}
+ * are notified correctly when an LRA terminates
+ */
+@ApplicationScoped
+@Path(AfterLRAListener.AFTER_LRA_LISTENER_PATH)
+public class AfterLRAListener {
+    public static final String AFTER_LRA_LISTENER_PATH = "after-lra-listener";
+    public static final String AFTER_LRA_LISTENER_WORK = "work";
+
+    private static final String AFTER_LRA = "/after";
+
+    @Inject
+    private LRAMetricService lraMetricService;
+
+    @PUT
+    @Path(AFTER_LRA_LISTENER_WORK)
+    @LRA(value = LRA.Type.REQUIRED, end = false)
+    public Response activityWithLRA(@HeaderParam(LRA_HTTP_RECOVERY_HEADER) URI recoveryId,
+                                    @HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        return Response.ok().build();
+    }
+
+    @PUT
+    @Path(AFTER_LRA)
+    @AfterLRA // this method will be called when the LRA associated with the method activityWithLRA finishes
+    public Response afterEnd(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus status) {
+        switch (status) {
+            case Closed:
+                // FALLTHRU
+            case Cancelled:
+                // FALLTHRU
+            case FailedToCancel:
+                // FALLTHRU
+            case FailedToClose:
+                lraMetricService.incrementMetric(
+                        LRAMetricType.valueOf(status.name()),
+                        lraId,
+                        AfterLRAListener.class.getName());
+                return Response.ok().build();
+            default:
+                return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/AfterLRAParticipant.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/AfterLRAParticipant.java
@@ -1,0 +1,104 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.lra.tck.participant.api;
+
+import org.eclipse.microprofile.lra.annotation.Compensate;
+import org.eclipse.microprofile.lra.annotation.Complete;
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.AfterLRA;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
+import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import java.net.URI;
+
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_CONTEXT_HEADER;
+import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_RECOVERY_HEADER;
+
+/**
+ * resource for testing that methods annotated with
+ * {@link AfterLRA}
+ * are notified correctly when an LRA terminates
+ */
+@ApplicationScoped
+@Path(AfterLRAParticipant.AFTER_LRA_PARTICIPANT_PATH)
+public class AfterLRAParticipant {
+    public static final String AFTER_LRA_PARTICIPANT_PATH = "after-lra-participant";
+    public static final String AFTER_LRA_PARTICIPANT_WORK = "work";
+
+    private static final String AFTER_LRA = "/after";
+
+    @Inject
+    private LRAMetricService lraMetricService;
+
+    @PUT
+    @Path("/complete")
+    @Complete
+    public Response completeWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId, String userData) {
+        lraMetricService.incrementMetric(LRAMetricType.Completed, lraId, AfterLRAParticipant.class.getName());
+        return Response.ok().build();
+    }
+
+    @PUT
+    @Path("/compensate")
+    @Compensate
+    public Response compensateWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId, String userData) {
+        lraMetricService.incrementMetric(LRAMetricType.Compensated, lraId, AfterLRAParticipant.class.getName());
+
+        return Response.ok().build();
+    }
+
+    @PUT
+    @Path(AFTER_LRA_PARTICIPANT_WORK)
+    @LRA(value = LRA.Type.REQUIRED, end = false)
+    public Response activityWithLRA(@HeaderParam(LRA_HTTP_RECOVERY_HEADER) URI recoveryId,
+                                    @HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        return Response.ok().build();
+    }
+
+    @PUT
+    @Path(AFTER_LRA)
+    @AfterLRA // this method will be called when the LRA associated with the method activityWithLRA finishes
+    public Response afterEnd(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus status) {
+        switch (status) {
+            case Closed:
+                // FALLTHRU
+            case Cancelled:
+                // FALLTHRU
+            case FailedToCancel:
+                // FALLTHRU
+            case FailedToClose:
+                lraMetricService.incrementMetric(
+                        LRAMetricType.valueOf(status.name()),
+                        lraId,
+                        AfterLRAParticipant.class.getName());
+                return Response.ok().build();
+            default:
+                return Response.status(Response.Status.BAD_REQUEST).build();
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ContextTckResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ContextTckResource.java
@@ -288,9 +288,9 @@ public class ContextTckResource {
     public Response compensateWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
                                    @HeaderParam(LRA_HTTP_PARENT_CONTEXT_HEADER) URI parent)
             throws NotFoundException {
-        lraMetricService.incrementMetric(LRAMetricType.COMPENSATE, lraId);
+        lraMetricService.incrementMetric(LRAMetricType.Compensated, lraId);
         if (parent != null) {
-            lraMetricService.incrementMetric(LRAMetricType.NESTED, parent);
+            lraMetricService.incrementMetric(LRAMetricType.Nested, parent);
         }
 
         return getEndPhaseResponse(false);
@@ -303,9 +303,9 @@ public class ContextTckResource {
     public Response completeWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
                                  @HeaderParam(LRA_HTTP_PARENT_CONTEXT_HEADER) URI parent)
             throws NotFoundException {
-        lraMetricService.incrementMetric(LRAMetricType.COMPLETE, lraId);
+        lraMetricService.incrementMetric(LRAMetricType.Completed, lraId);
         if (parent != null) {
-            lraMetricService.incrementMetric(LRAMetricType.NESTED, parent);
+            lraMetricService.incrementMetric(LRAMetricType.Nested, parent);
         }
 
         return getEndPhaseResponse(true);
@@ -317,9 +317,9 @@ public class ContextTckResource {
     @Status
     public Response status(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
                            @HeaderParam(LRA_HTTP_PARENT_CONTEXT_HEADER) URI parent) {
-        lraMetricService.incrementMetric(LRAMetricType.STATUS, lraId);
+        lraMetricService.incrementMetric(LRAMetricType.Status, lraId);
         if (parent != null) {
-            lraMetricService.incrementMetric(LRAMetricType.NESTED, parent);
+            lraMetricService.incrementMetric(LRAMetricType.Nested, parent);
         }
 
         return Response.status(endPhaseStatus).entity(status.name()).build();
@@ -331,9 +331,9 @@ public class ContextTckResource {
     @Forget
     public Response forget(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
                            @HeaderParam(LRA_HTTP_PARENT_CONTEXT_HEADER) URI parent) {
-        lraMetricService.incrementMetric(LRAMetricType.FORGET, lraId);
+        lraMetricService.incrementMetric(LRAMetricType.Forget, lraId);
         if (parent != null) {
-            lraMetricService.incrementMetric(LRAMetricType.NESTED, parent);
+            lraMetricService.incrementMetric(LRAMetricType.Nested, parent);
         }
 
         return Response.status(endPhaseStatus).entity(status.name()).build();

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraCancelOnController.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraCancelOnController.java
@@ -183,7 +183,7 @@ public class LraCancelOnController {
             throw new NullPointerException("lraId can't be null as it should be invoked with the context");
         }
 
-        lraMetricService.incrementMetric(LRAMetricType.COMPLETE, lraId);
+        lraMetricService.incrementMetric(LRAMetricType.Completed, lraId);
 
         LOGGER.info(String.format("LRA id '%s' was completed", lraId.toASCIIString()));
         return Response.ok().build();
@@ -198,7 +198,7 @@ public class LraCancelOnController {
             throw new NullPointerException("lraId can't be null as it should be invoked with the context");
         }
 
-        lraMetricService.incrementMetric(LRAMetricType.COMPENSATE, lraId);
+        lraMetricService.incrementMetric(LRAMetricType.Compensated, lraId);
 
         LOGGER.info(String.format("LRA id '%s' was compensated", lraId.toASCIIString()));
         return Response.ok().build();

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraController.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraController.java
@@ -140,9 +140,9 @@ public class LraController {
     @Complete
     public Response completeWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId, String userData)
         throws NotFoundException {
-        lraMetricService.incrementMetric(LRAMetricType.COMPLETE, lraId, LraController.class.getName());
+        lraMetricService.incrementMetric(LRAMetricType.Completed, lraId, LraController.class.getName());
 
-        assertHeaderPresent(lraId); // the TCK expects the coordinator to invoke @Complete methods
+        assertHeaderPresent(lraId); // the TCK expects the coordinator to invoke @Completed methods
 
         Activity activity = activityStore.getActivityAndAssertExistence(lraId, context);
 
@@ -170,9 +170,9 @@ public class LraController {
     public Response compensateWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId, String userData)
         throws NotFoundException {
 
-        assertHeaderPresent(lraId); // the TCK expects the coordinator to invoke @Compensate methods
+        assertHeaderPresent(lraId); // the TCK expects the coordinator to invoke @Compensated methods
 
-        lraMetricService.incrementMetric(LRAMetricType.COMPENSATE, lraId, LraController.class.getName());
+        lraMetricService.incrementMetric(LRAMetricType.Compensated, lraId, LraController.class.getName());
 
         Activity activity = activityStore.getActivityAndAssertExistence(lraId, context);
 
@@ -198,7 +198,7 @@ public class LraController {
     @Produces(MediaType.APPLICATION_JSON)
     @Forget
     public Response forgetWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId) {
-        lraMetricService.incrementMetric(LRAMetricType.COMPLETE, lraId, LraController.class.getName());
+        lraMetricService.incrementMetric(LRAMetricType.Forget, lraId, LraController.class.getName());
 
         assertHeaderPresent(lraId); // the TCK expects the coordinator to invoke @Forget methods
 

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ParticipatingTckResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ParticipatingTckResource.java
@@ -94,9 +94,9 @@ public class ParticipatingTckResource {
         }
 
         if (complete) {
-            lraMetricService.incrementMetric(LRAMetricType.COMPLETE, lraId, ParticipatingTckResource.class.getName());
+            lraMetricService.incrementMetric(LRAMetricType.Completed, lraId, ParticipatingTckResource.class.getName());
         } else {
-            lraMetricService.incrementMetric(LRAMetricType.COMPENSATE, lraId, ParticipatingTckResource.class.getName());
+            lraMetricService.incrementMetric(LRAMetricType.Compensated, lraId, ParticipatingTckResource.class.getName());
         }
 
         return Response.ok().build();

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/nonjaxrs/valid/ValidLRACSParticipant.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/nonjaxrs/valid/ValidLRACSParticipant.java
@@ -79,7 +79,7 @@ public class ValidLRACSParticipant {
         assert lraId != null;
         
         return CompletableFuture.runAsync(() -> {
-            lraMetricService.incrementMetric(LRAMetricType.COMPENSATE, lraId);
+            lraMetricService.incrementMetric(LRAMetricType.Compensated, lraId);
             
             simulateLongRunningCompensation();
         });
@@ -90,7 +90,7 @@ public class ValidLRACSParticipant {
         assert lraId != null;
         
         return CompletableFuture.supplyAsync(() -> {
-            lraMetricService.incrementMetric(LRAMetricType.COMPLETE, lraId);
+            lraMetricService.incrementMetric(LRAMetricType.Completed, lraId);
             
             simulateLongRunningCompensation();
             return Response.accepted().build(); // Completing
@@ -102,7 +102,7 @@ public class ValidLRACSParticipant {
         assert lraId != null;
         
         return CompletableFuture.supplyAsync(() -> {
-            lraMetricService.incrementMetric(LRAMetricType.STATUS, lraId);
+            lraMetricService.incrementMetric(LRAMetricType.Status, lraId);
             
             simulateLongRunningCompensation();
             return ParticipantStatus.Completed;

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRAMetricType.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRAMetricType.java
@@ -19,11 +19,26 @@
  *******************************************************************************/
 package org.eclipse.microprofile.lra.tck.service;
 
+import org.eclipse.microprofile.lra.annotation.LRAStatus;
+import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
+
 public enum LRAMetricType {
-    
-    COMPENSATE,
-    COMPLETE,
-    STATUS,
-    FORGET,
-    NESTED
+    // LRA statistics
+    Closed(LRAStatus.Closed.name()), // an LRA that closed
+    FailedToClose(LRAStatus.FailedToClose.name()), // an LRA that failed to close
+    Cancelled(LRAStatus.Cancelled.name()), // an LRA that was cancelled
+    FailedToCancel(LRAStatus.FailedToCancel.name()), // an LRA that failed to cancel
+
+    // Participant statistics
+    Compensated(ParticipantStatus.Compensated.name()), // a participant that was asked to compensate
+    Completed(ParticipantStatus.Completed.name()), // a participant that was asked to complete
+    Status("Status"), // a participant that was asked for its status
+    Forget("Forget"), // a participant that was told to forget
+    Nested("Nested"), // a participant callback that was invoked in the context of a parent LRA
+
+    // Other statistics
+    AfterLRA("AfterLRA"); // a listener that has received a notification that an LRA finished
+
+    LRAMetricType(String label) {
+    }
 }


### PR DESCRIPTION
#164 

If a resource is invoked in the context of an LRA and it contains a JAX-RS resource method annotated with `@AfterEnd` then it will be notified when the associated LRA is finished (in any of the terminal states).