### PR TITLE
issue164-update Typo in test TckTests#testAfterLRAListener

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
@@ -258,7 +258,7 @@ public class TckTests extends TckTestBase {
         // verify that the resource was notified of the final state of the LRA
         assertEquals("testAfterLRAListener: end synchronization was not invoked on resource " + resourcePath.getUri(),
                 1,
-                lraMetricService.getMetric(LRAMetricType.Closed, lra, AfterLRAParticipant.class.getName()));
+                lraMetricService.getMetric(LRAMetricType.Closed, lra, AfterLRAListener.class.getName()));
     }
 
     @Test


### PR DESCRIPTION
#164 

The fix for the issue contains a typo in the test TckTests#testAfterLRAListener. The test asserts on the wrong metric (AfterLRAParticipant instead of AfterLRAListener).