### PR TITLE
issue146 Specifiy JAX-RS request methods on annotations

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/lra/annotation/AfterLRA.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/annotation/AfterLRA.java
@@ -37,7 +37,8 @@ import java.lang.annotation.Target;
  *
  * <p>
  * If the <code>AfterLRA</code> method is also a JAX-RS resource method
- * then the LRA context is made available to the annotated method
+ * then it MUST use the {@link javax.ws.rs.PUT} request method. In this
+ * case the LRA context is made available to the annotated method
  * via an HTTP header with the name
  * {@link LRA#LRA_HTTP_ENDED_CONTEXT_HEADER} and the
  * final status is passed to the method as plain text

--- a/api/src/main/java/org/eclipse/microprofile/lra/annotation/Compensate.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/annotation/Compensate.java
@@ -38,7 +38,8 @@ import java.time.temporal.ChronoUnit;
  * </p>
  *
  * <p>
- * If the annotation is applied to a JAX-RS resource method then the id of the currently
+ * If the annotation is applied to a JAX-RS resource method then the request
+ * method MUST be {@link javax.ws.rs.PUT}. The id of the currently
  * running LRA can be obtained by inspecting the incoming JAX-RS headers. If
  * this LRA is nested then the parent LRA MUST be present in the header with the name
  * {@link org.eclipse.microprofile.lra.annotation.ws.rs.LRA#LRA_HTTP_PARENT_CONTEXT_HEADER}

--- a/api/src/main/java/org/eclipse/microprofile/lra/annotation/Complete.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/annotation/Complete.java
@@ -40,7 +40,8 @@ import java.time.temporal.ChronoUnit;
  * </p>
  *
  * <p>
- * If the annotation is applied to a JAX-RS resource method then the id of the currently
+ * If the annotation is applied to a JAX-RS resource method then the request
+ * method MUST be {@link javax.ws.rs.PUT}. The id of the currently
  * running LRA can be obtained by inspecting the incoming JAX-RS headers. If
  * this LRA is nested then the parent LRA MUST be present in the header with the name
  * {@link org.eclipse.microprofile.lra.annotation.ws.rs.LRA#LRA_HTTP_PARENT_CONTEXT_HEADER}

--- a/api/src/main/java/org/eclipse/microprofile/lra/annotation/Forget.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/annotation/Forget.java
@@ -46,7 +46,8 @@ import java.lang.annotation.Target;
  * </p>
  *
  * <p>
- * If the annotated method is a JAX-RS resource method the id of the currently
+ * If the annotation is applied to a JAX-RS resource method then the request
+ * method MUST be {@link javax.ws.rs.DELETE}. The id of the currently
  * running LRA can be obtained by inspecting the incoming JAX-RS headers. If
  * this LRA is nested then the parent LRA MUST be present in the header with the name
  * {@link LRA#LRA_HTTP_PARENT_CONTEXT_HEADER}

--- a/api/src/main/java/org/eclipse/microprofile/lra/annotation/Status.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/annotation/Status.java
@@ -42,7 +42,8 @@ import java.lang.annotation.Target;
  * </p>
  *
  * <p>
- * If the annotated method is a JAX-RS resource method the id of the currently
+ * If the annotation is applied to a JAX-RS resource method then the request
+ * method MUST be {@link javax.ws.rs.GET}. The id of the currently
  * running LRA can be obtained by inspecting the incoming JAX-RS headers. If
  * this LRA is nested then the parent LRA MUST be present in the header with the name
  * {@link org.eclipse.microprofile.lra.annotation.ws.rs.LRA#LRA_HTTP_PARENT_CONTEXT_HEADER}

--- a/spec/src/main/asciidoc/microprofile-lra-spec.adoc
+++ b/spec/src/main/asciidoc/microprofile-lra-spec.adoc
@@ -755,7 +755,7 @@ annotations when associated with JAX-RS resource methods:
 
 [[jaxrs-response-table]]
 |===
-| Annotation | Prefered HTTP method | Expected status codes | Response
+| Annotation | Required HTTP method | Expected status codes | Response
 
 | `@Compensate`
 | PUT
@@ -786,9 +786,6 @@ annotations when associated with JAX-RS resource methods:
 
 Please refer to the javadoc for each annotation for the description of the
 conditions under which the various JAX-RS response codes are returned.
-
-The presented HTTP methods SHOULD be applied at individual JAX-RS methods
-but they are not enforced by the specification. 
 
 If the method annotated with `@AfterLRA` returns an unexpected HTTP status
 or never reaches the caller then the implementation MUST invoke the same method again.
@@ -911,7 +908,15 @@ is still in progress using one of the following options:
   it exists, and if there is no such method it will reinvoke the `@Compensate`
   method). Please refer to the section
   <<reactive-support,about reactive support>> for more details.
-- A JAX-RS method can return a `202 Accepted` HTTP status code
+- A JAX-RS method can return a `202 Accepted` HTTP status code.
+  If there is no `@Status` method then the response MAY provide
+  a status URL in the `HTTP Location` header field so that the
+  implementation can discover the final outcome.
+  This URL, if present, MUST obey the requirements specificed in
+  the javadoc for the <<source-Status,Status annotation>>.
+  If the developer has not provided an `@Status` method nor a status
+  URL then the implementation MUST reinvoke the `@Compensate` method
+  (ie it MUST be idempotent).
 - A non JAX-RS method can return `ParticipantStatus.Compensating`.
 
 The `@Status` method, if present, MUST report the progress of the compensation.
@@ -1270,6 +1275,13 @@ include::{sourcedir}/org/eclipse/microprofile/lra/annotation/Compensate.java[Com
 [[source-Complete]]
 ----
 include::{sourcedir}/org/eclipse/microprofile/lra/annotation/Complete.java[Leave]
+----
+<<<
+
+=== Status Annotation
+[[source-Status]]
+----
+include::{sourcedir}/org/eclipse/microprofile/lra/annotation/Status.java/[Status]
 ----
 <<<
 

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ContextTckResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/ContextTckResource.java
@@ -33,6 +33,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
@@ -280,8 +281,7 @@ public class ContextTckResource {
         return Response.ok().entity(lraId.toASCIIString()).build();
     }
 
-    // Compensate methods SHOULD use @PUT but to verify that other HTTP methods are also supported use here HTTP GET
-    @GET
+    @PUT
     @Path("/compensate")
     @Compensate
     public Response compensateWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
@@ -294,8 +294,7 @@ public class ContextTckResource {
         return getEndPhaseResponse(false);
     }
 
-    // Complete methods SHOULD use @PUT but to verify that other HTTP methods are also supported use here HTTP POST
-    @POST
+    @PUT
     @Path("/complete")
     @Complete
     public Response completeWork(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
@@ -308,8 +307,7 @@ public class ContextTckResource {
         return getEndPhaseResponse(true);
     }
 
-    // Status methods SHOULD use @GET but to verify that other HTTP methods are also supported use HTTP PUT
-    @PUT
+    @GET
     @Path(STATUS_PATH)
     @Status
     public Response status(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
@@ -322,8 +320,7 @@ public class ContextTckResource {
         return Response.status(endPhaseStatus).entity(status.name()).build();
     }
 
-    // Forget methods SHOULD use @DELETE but to verify that other HTTP methods are also supported use HTTP PUT
-    @PUT
+    @DELETE
     @Path("/forget")
     @Forget
     public Response forget(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,


### PR DESCRIPTION
#146 

This PR clarifies which JAX-RS request methods can be used on annotations.

@rdebusscher I added a note about including an optional status URL in `202 Accepted` responses to cover the situation where there is no `@Status` method. If you accept this text then I don't think we need a new issue for it.

I also did not change any text that discussed idempotency since we are still discussing that on issue #187