### PR TITLE
Fix some TCK tests of #205 and improve 

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownStatusTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownStatusTests.java
@@ -50,7 +50,7 @@ public class TckUnknownStatusTests extends TckTestBase {
 
     @Deployment(name = "tckunkownstatus")
     public static WebArchive deploy() {
-        return TckUnknownStatusTests.deploy(TckTests.class.getSimpleName().toLowerCase());
+        return TckUnknownStatusTests.deploy(TckUnknownStatusTests.class.getSimpleName().toLowerCase());
     }
 
     @Before
@@ -69,10 +69,10 @@ public class TckUnknownStatusTests extends TckTestBase {
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int cancelled = lraMetricService.getMetric(LRAMetricType.Cancelled, lraId);
 
-        assertEquals(1, compensated);
-        assertEquals(1, status);
-        assertEquals(1, afterLRA);
-        assertEquals(1, cancelled);
+        assertEquals("Number of calls to @Compensate incorrect",1, compensated);
+        assertEquals("Number of calls to @Status incorrect",1, status);
+        assertEquals("Number of calls to @AfterLRA incorrect",1, afterLRA);
+        assertEquals("Final LRA status of Cancelled incorrect",1, cancelled);
     }
 
     @Test
@@ -86,10 +86,10 @@ public class TckUnknownStatusTests extends TckTestBase {
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int closed = lraMetricService.getMetric(LRAMetricType.Closed, lraId);
 
-        assertEquals(1, completed);
-        assertEquals(1, status);
-        assertEquals(1, afterLRA);
-        assertEquals(1, closed);
+        assertEquals("Number of calls to @Complete incorrect",1, completed);
+        assertEquals("Number of calls to @Status incorrect",1, status);
+        assertEquals("Number of calls to @AfterLRA incorrect",1, afterLRA);
+        assertEquals("Final LRA status of Closed incorrect",1, closed);
     }
 
     private String invoke(Scenario scenario) {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownTests.java
@@ -35,7 +35,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
-
 import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
@@ -69,9 +68,9 @@ public class TckUnknownTests extends TckTestBase {
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int cancelled = lraMetricService.getMetric(LRAMetricType.Cancelled, lraId);
 
-        assertEquals(1, compensated);
-        assertEquals(1, afterLRA);
-        assertEquals(1, cancelled);
+        assertEquals("Number of calls to @Compensate incorrect", 1, compensated);
+        assertEquals("Number of calls to @AfterLRA incorrect", 1, afterLRA);
+        assertEquals("Final LRA status of Cancelled incorrect", 1, cancelled);
     }
 
     @Test
@@ -84,9 +83,9 @@ public class TckUnknownTests extends TckTestBase {
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int cancelled = lraMetricService.getMetric(LRAMetricType.Cancelled, lraId);
 
-        assertEquals(2, compensated);
-        assertEquals(1, afterLRA);
-        assertEquals(1, cancelled);
+        assertEquals("Number of calls to @Compensate incorrect", 2, compensated);
+        assertEquals("Number of calls to @AfterLRA incorrect", 1, afterLRA);
+        assertEquals("Final LRA status of Cancelled incorrect", 1, cancelled);
     }
 
     @Test
@@ -99,9 +98,9 @@ public class TckUnknownTests extends TckTestBase {
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int closed = lraMetricService.getMetric(LRAMetricType.Closed, lraId);
 
-        assertEquals(1, completed);
-        assertEquals(1, afterLRA);
-        assertEquals(1, closed);
+        assertEquals("Number of calls to @Complete incorrect", 1, completed);
+        assertEquals("Number of calls to @AfterLRA incorrect", 1, afterLRA);
+        assertEquals("Final LRA status of Closed incorrect",1, closed);
     }
 
     @Test
@@ -114,9 +113,9 @@ public class TckUnknownTests extends TckTestBase {
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int closed = lraMetricService.getMetric(LRAMetricType.Closed, lraId);
 
-        assertEquals(2, completed);
-        assertEquals(1, afterLRA);
-        assertEquals(1, closed);
+        assertEquals("Number of calls to @Complete incorrect", 2, completed);
+        assertEquals("Number of calls to @AfterLRA incorrect", 1, afterLRA);
+        assertEquals("Final LRA status of Closed incorrect",1, closed);
     }
 
     private String invoke(Scenario scenario) {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LRAUnknownResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LRAUnknownResource.java
@@ -50,7 +50,6 @@ import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_C
  */
 @ApplicationScoped
 @Path(LRAUnknownResource.LRA_CONTROLLER_PATH)
-@LRA
 public class LRAUnknownResource {
     public static final String LRA_CONTROLLER_PATH = "lraUnknownController";
     public static final String TRANSACTIONAL_WORK_PATH = "work";
@@ -65,6 +64,7 @@ public class LRAUnknownResource {
 
     @PUT
     @Path(TRANSACTIONAL_WORK_PATH)
+    @LRA
     public Response activityWithLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId
             , @QueryParam("scenario") Scenario scenario) {
 

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LRAUnknownResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LRAUnknownResource.java
@@ -143,8 +143,7 @@ public class LRAUnknownResource {
             case FailedToClose:
                 lraMetricService.incrementMetric(
                         LRAMetricType.valueOf(status.name()),
-                        lraId,
-                        LRAUnknownResource.class.getName());
+                        lraId);
                 return Response.ok().build();
             default:
                 return Response.status(Response.Status.BAD_REQUEST).build();

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LRAUnknownStatusResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LRAUnknownStatusResource.java
@@ -52,7 +52,6 @@ import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_ENDED_C
  */
 @ApplicationScoped
 @Path(LRAUnknownStatusResource.LRA_CONTROLLER_PATH)
-@LRA
 public class LRAUnknownStatusResource {
     public static final String LRA_CONTROLLER_PATH = "lraUnknownStatusController";
     public static final String TRANSACTIONAL_WORK_PATH = "work";
@@ -67,6 +66,7 @@ public class LRAUnknownStatusResource {
 
     @PUT
     @Path(TRANSACTIONAL_WORK_PATH)
+    @LRA
     public Response activityWithLRA(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId
             , @QueryParam("scenario") Scenario scenario) {
 

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LRAUnknownStatusResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LRAUnknownStatusResource.java
@@ -154,8 +154,7 @@ public class LRAUnknownStatusResource {
             case FailedToClose:
                 lraMetricService.incrementMetric(
                         LRAMetricType.valueOf(status.name()),
-                        lraId,
-                        LRAUnknownStatusResource.class.getName());
+                        lraId);
                 return Response.ok().build();
             default:
                 return Response.status(Response.Status.BAD_REQUEST).build();


### PR DESCRIPTION
Fix: LRA Status was reported with Class name but consulted without from MetricService
Improve: correct deployment name, better assert messages, ...