### PR TITLE
Remove conflicting LRA annotation from LraResource#status method

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraResource.java
@@ -95,7 +95,6 @@ public class LraResource {
     @Path("/status")
     @Produces(MediaType.APPLICATION_JSON)
     @Status
-    @LRA(value = LRA.Type.NOT_SUPPORTED)
     public Response status(@HeaderParam(LRA_HTTP_CONTEXT_HEADER) URI lraId,
                            @HeaderParam(LRA_HTTP_RECOVERY_HEADER) URI recoveryId) {
 


### PR DESCRIPTION
JavaDoc for NOT_SUPPORTED case:

```java
/**
* <p>
*     The resource method is executed without an LRA context.
* </p>
*/
NOT_SUPPORTED,
```

however, the method checks that LRA_HTTP_CONTEXT_HEADER is received on line 102. 

Signed-off-by: xstefank <xstefank122@gmail.com>