### PR TITLE
Add an option to skip specification asciidoc plugin

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -32,6 +32,7 @@
     <properties>
         <asciidoctor-maven.version>1.5.5</asciidoctor-maven.version>
         <asciidoctorj-pdf.version>1.5.0-alpha.15</asciidoctorj-pdf.version>
+        <asciidoc.skip>false</asciidoc.skip>
         <license>Apache License v 2.0</license>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
@@ -85,6 +86,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <skip>${asciidoc.skip}</skip>
                     <sourceDocumentName>microprofile-lra-spec.adoc</sourceDocumentName>
                     <sourceHighlighter>coderay</sourceHighlighter>
                     <attributes>


### PR DESCRIPTION
Signed-off-by: xstefank <xstefank122@gmail.com>

Specification document asciidoctor processing takes a lot of time during compilations. This PR adds an option to skip the generating of the spec document when passing -Dasciidoc.skip=true to the build. This saves ~20s on my machines which is really helpful.