### PR TITLE
issue249 Replace short and long delays with calls to LRARecoveryService

### DIFF
--- a/tck/running_the_tck.asciidoc
+++ b/tck/running_the_tck.asciidoc
@@ -109,6 +109,12 @@ but that provide a way to deploy and undeploy deployments. That container to be 
 <arquillian>
 ----
 
+== SPI
+
+* The TCK provides an SPI `LRARecoveryService` which is retrived through the
+`ServiceLoader` mechanism. The implmenter is required to provide an
+implementation of this interface in order to run the TCK.
+
 == Debugging tests
 
 Debugging is dependent on the TCK implementor. The implementor configures Arquillian to use particular runtime
@@ -116,8 +122,3 @@ to deploy the test deployments and run the LRA client side implementation there.
 the runtime needs to define java debug properties `-Xdebug -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y`.
 Then debugger may be connected to port 8787 and to track the test execution.
 
-== Additional notes
-
-* `TckTestBase#replayEndPhase(String)` method, used for instance in `@Status` and 
-`@Forget` call verifications, expects that recovery happens on all active LRAs in 
-a reasonable time frame defined by the configuration property `lra.tck.recovery.timeout`.

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/LraTckConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/LraTckConfigBean.java
@@ -24,8 +24,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.eclipse.microprofile.lra.annotation.LRAStatus;
-import org.eclipse.microprofile.lra.annotation.ParticipantStatus;
 
 @ApplicationScoped
 public class LraTckConfigBean {
@@ -51,73 +49,6 @@ public class LraTckConfigBean {
     private double timeoutFactor;
 
     /**
-     * <p>
-     *     The LRA model guarantees eventual consistency but does not say when
-     *     participants will be brought into a consistent state, for example an
-     *     implementation may not notify participants immediately when an LRA
-     *     is closed or cancelled.
-     *
-     *     To support implementations that do not immediately attempt to notify
-     *     participants the TCK needs to know how long to delay before checking whether
-     *     or not the implementation called them.
-     *     This delay will depend on the particular implementation so it is
-     *     configurable, i.e, use this property to configure the number of
-     *     milliseconds that a test will wait for before it checks if a complete
-     *     or compensate method has been called.
-     *
-     *     There are two properties for configuring delays. The long version should be
-     *     used when multiple calls to these participant methods needs to be performed.
-     *
-     *     The default is set to zero which implies that the implementation will
-     *     notify participants as soon as the LRA enters the
-     *     {@link LRAStatus#Closing} or {@link LRAStatus#Cancelling}
-     *     states. Note that this does not imply that the participant will
-     *     complete or compensate immediately since it may enter the
-     *     {@link ParticipantStatus#Completing} or {@link ParticipantStatus#Compensating}
-     *     states first if a participant cannot clean up or compensate immediately.
-     * </p>
-     */
-    @Inject @ConfigProperty(name = "lra.tck.consistency.longDelay", defaultValue = "0")
-    private long longConsistencyDelay;
-
-    /**
-     * <p>
-     *     An alternative to @see LraTckConfigBean#longConsistencyDelay
-     *     This can be useful if the consistency delay needs to be changed for some tests
-     *
-     *     There are two properties for configuring delays. The short version should be
-     *     used when we just need to wait for the implementation to call the participant methods
-     * </p>
-     */
-    @Inject @ConfigProperty(name = "lra.tck.consistency.shortDelay", defaultValue = "0")
-    private long shortConsistencyDelay;
-
-    /**
-     * <p>
-     *     the maximum number of seconds to wait for recovery
-     * </p>
-     */
-    @Inject @ConfigProperty(name = "lra.tck.recovery.timeout", defaultValue = "200")
-    private long recoveryTimeout;
-
-    /**
-     * If true then the TCK should use the recovery header to give a hint to the implementation
-     * under test that it should replay the LRA protocol termination phase ie to call the
-     * compensate/complete callback on target resource (if the resource is also an LRA participant
-     * and is in need of recovery).
-     *
-     * See the method {@link TckTestBase#replayEndPhase} for how/where it is used. The replayEndPhase
-     * method will keep waiting for recovery until either recovery has been triggered or until
-     * {@link #recoveryTimeout} seconds have elapsed.
-     *
-     * Implementations that do not support triggering recovery should ensure that the
-     * {@link #recoveryTimeout} value is set to a value that is longer than the implementations
-     * typical recovery period.
-     */
-    @Inject @ConfigProperty(name = "lra.tck.recovery.trigger", defaultValue = "true")
-    private boolean useRecoveryHeader;
-
-    /**
      * Base URL where the LRA suite is started at. It's URL where container exposes the test suite deployment.
      * The test paths will be constructed based on this base URL.
      * <p>
@@ -129,22 +60,6 @@ public class LraTckConfigBean {
 
     public double timeoutFactor() {
         return timeoutFactor;
-    }
-
-    public long getLongConsistencyDelay() {
-        return longConsistencyDelay;
-    }
-
-    public long getShortConsistencyDelay() {
-        return shortConsistencyDelay;
-    }
-
-    public Long recoveryTimeout() {
-        return recoveryTimeout;
-    }
-
-    public boolean isUseRecoveryHeader() {
-        return useRecoveryHeader;
     }
 
     public String tckSuiteBaseUrl() {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckCancelOnTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckCancelOnTests.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.lra.tck;
 import org.eclipse.microprofile.lra.tck.participant.api.LraCancelOnResource;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
+import org.eclipse.microprofile.lra.tck.service.LRATestService;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -43,6 +44,9 @@ public class TckCancelOnTests extends TckTestBase {
 
     @Inject
     private LRAMetricService lraMetricService;
+
+    @Inject
+    private LRATestService lraTestService;
     
     @Deployment(name = "tcktests-cancelon")
     public static WebArchive deploy() {
@@ -64,7 +68,7 @@ public class TckCancelOnTests extends TckTestBase {
         Response response = resourcePath.request().get();
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.BAD_REQUEST, response, resourcePath));
-        applyShortConsistencyDelay();
+        lraTestService.waitForCallbacks(lraId);
         assertEquals("After 400 compensate should be invoked", 
             1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("After 400 complete can't be invoked", 
@@ -82,7 +86,7 @@ public class TckCancelOnTests extends TckTestBase {
         Response response = resourcePath.request().get();
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.INTERNAL_SERVER_ERROR, response, resourcePath));
-        applyShortConsistencyDelay();
+        lraTestService.waitForCallbacks(lraId);
         assertEquals("After 500 compensate should be invoked", 
             1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("After 500 complete can't be invoked", 
@@ -100,7 +104,7 @@ public class TckCancelOnTests extends TckTestBase {
         Response response = resourcePath.request().get();
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.SEE_OTHER, response, resourcePath));
-        applyShortConsistencyDelay();
+        lraTestService.waitForCallbacks(lraId);
         assertEquals("After status code 303 is received, compensate should be invoked as set by attribute cancelOnFamily",
                 1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("After status code 303 is received, complete can't be invoked as not defined in annotation @LRA",
@@ -118,7 +122,7 @@ public class TckCancelOnTests extends TckTestBase {
         Response response = resourcePath.request().get();
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.MOVED_PERMANENTLY, response, resourcePath));
-        applyShortConsistencyDelay();
+        lraTestService.waitForCallbacks(lraId);
         assertEquals("After status code 301 is received, compensate should be invoked as set by attribute cancelOn",
                 1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("After status code 301 is received, complete can't be invoked as not defined in annotation @LRA",
@@ -136,7 +140,7 @@ public class TckCancelOnTests extends TckTestBase {
         Response response = resourcePath.request().get();
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.INTERNAL_SERVER_ERROR, response, resourcePath));
-        applyShortConsistencyDelay();
+        lraTestService.waitForCallbacks(lraId);
         assertEquals("After status code 500 is received, compensate can't be invoked as default behaviour was changed",
                 0, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("After status code 500 is received, complete has to be called as default behaviour was changed",
@@ -154,7 +158,7 @@ public class TckCancelOnTests extends TckTestBase {
         Response response = resourcePath.request().get();
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.OK, response, resourcePath));
-        applyShortConsistencyDelay();
+        lraTestService.waitForCallbacks(lraId);
         // LraCancelOnResource enlists twice the same participant, compensate is expected to be called only once
         assertEquals("Status was 200 but compensate should be called as LRA should be cancelled for remotely called participant as well",
                 1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckParticipantTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckParticipantTests.java
@@ -23,7 +23,7 @@ import org.eclipse.microprofile.lra.tck.participant.nonjaxrs.valid.ValidLRACSPar
 import org.eclipse.microprofile.lra.tck.participant.nonjaxrs.valid.ValidLRAParticipant;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
-import org.eclipse.microprofile.lra.tck.service.spi.LraRecoveryService;
+import org.eclipse.microprofile.lra.tck.service.LRATestService;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -52,7 +52,7 @@ public class TckParticipantTests extends TckTestBase {
     private LRAMetricService lraMetricService;
 
     @Inject
-    private LraRecoveryService lraRecoveryService;
+    private LRATestService lraTestService;
 
     @Deployment
     public static WebArchive deployValidParticipant() {
@@ -114,7 +114,7 @@ public class TckParticipantTests extends TckTestBase {
         assertEquals("@Complete method should not have been called as LRA compensated",
             0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
 
-        lraRecoveryService.triggerRecovery(lraId);
+        lraTestService.waitForRecovery(lraId);
 
         assertEquals("Non JAX-RS @Status method should have been called", 
             1, lraMetricService.getMetric(LRAMetricType.Status, lraId));
@@ -141,7 +141,7 @@ public class TckParticipantTests extends TckTestBase {
         assertEquals("Non JAX-RS @Complete method should have not been called",
             0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
 
-        lraRecoveryService.triggerRecovery(lraId);
+        lraTestService.waitForRecovery(lraId);
     }
 
     /**
@@ -165,11 +165,11 @@ public class TckParticipantTests extends TckTestBase {
         assertEquals("Non JAX-RS @Compensate method should have not been called",
             0, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
 
-        lraRecoveryService.triggerRecovery(lraId);
+        lraTestService.waitForRecovery(lraId);
 
         assertEquals("Non JAX-RS @Status method with CompletionStage<ParticipantStatus> should have been called",
             1, lraMetricService.getMetric(LRAMetricType.Status, lraId));
         
-        lraRecoveryService.triggerRecovery(lraId);
+        lraTestService.waitForRecovery(lraId);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTestBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTestBase.java
@@ -19,13 +19,12 @@
  *******************************************************************************/
 package org.eclipse.microprofile.lra.tck;
 
-import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
 import org.eclipse.microprofile.lra.tck.participant.activity.Activity;
 import org.eclipse.microprofile.lra.tck.participant.api.LraResource;
 import org.eclipse.microprofile.lra.tck.participant.api.Util;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
 import org.eclipse.microprofile.lra.tck.service.LRATestService;
-import org.eclipse.microprofile.lra.tck.service.spi.LraRecoveryService;
+import org.eclipse.microprofile.lra.tck.service.spi.LRARecoveryService;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -35,15 +34,10 @@ import org.junit.Rule;
 import org.junit.rules.TestName;
 
 import javax.inject.Inject;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.util.logging.Logger;
 
-import static org.eclipse.microprofile.lra.tck.participant.api.ParticipatingTckResource.ACCEPT_PATH;
-import static org.eclipse.microprofile.lra.tck.participant.api.ParticipatingTckResource.RECOVERY_PARAM;
-import static org.eclipse.microprofile.lra.tck.participant.api.ParticipatingTckResource.TCK_PARTICIPANT_RESOURCE_PATH;
 import static org.junit.Assert.assertEquals;
 
 public class TckTestBase {
@@ -72,7 +66,7 @@ public class TckTestBase {
                 Activity.class.getPackage(),
                 LraResource.class.getPackage(),
                 LRAMetricService.class.getPackage(),
-                LraRecoveryService.class.getPackage())
+                LRARecoveryService.class.getPackage())
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
     
@@ -122,71 +116,5 @@ public class TckTestBase {
      */
     long lraTimeout() {
         return Util.adjust(LraTckConfigBean.LRA_TIMEOUT_MILLIS, config.timeoutFactor());
-    }
-
-    void applyShortConsistencyDelay() {
-        lraTestService.applyShortConsistencyDelay();
-    }
-
-    void  applyLongConsistencyDelay() {
-        lraTestService.applyLongConsistencyDelay();
-    }
-
-    /**
-     * Trigger or wait for a recovery scan to replay the protocol termination phase (complete or compensate)
-     * on a participant that is in need of recovery.
-     *
-     * @param resource the resource on which recovery should be replayed. If null then recovery
-     *                should be attempted on all eligible participants
-     * @throws InterruptedException When Thread is interrupted during sleep.
-     */
-    void replayEndPhase(String resource) throws InterruptedException {
-        // trigger a replay attempt on any participants
-        // that have responded to complete/compensate requests with Response.Status.ACCEPTED
-
-        /*
-         * The following variable is for keeping track of the number of completion calls made
-         * on the resource (TCK_PARTICIPANT_RESOURCE_PATH). It is initialised with the value 2
-         * and then passed to the resource. We then loop asking the resource to report its
-         * current value. The resource will decrement the value each time it is asked to complete.
-         * When the return value hits zero we will know that recovery has happened.
-         */
-        int recoveryPasses = 2; // 1 for the normal end call and 2 for the recovery pass call
-        long maxWait = config.recoveryTimeout(); // how long to wait before giving up on recovery
-        WebTarget resourcePath = tckSuiteTarget.path(TCK_PARTICIPANT_RESOURCE_PATH).path(ACCEPT_PATH)
-                .queryParam(RECOVERY_PARAM, recoveryPasses);
-        Response response = resourcePath.request().put(Entity.text(""));
-
-        checkStatusAndCloseResponse(Response.Status.OK, response, resourcePath);
-
-        do {
-            Invocation.Builder builder = resourcePath.request();
-
-            if (config.isUseRecoveryHeader()) {
-                builder.header(LRA.LRA_HTTP_RECOVERY_HEADER, resource);
-            }
-
-            response = resourcePath.request().get();
-
-            // the resource will tell us how many more times it is expected to be asked to complete
-            recoveryPasses = Integer.valueOf(checkStatusReadAndCloseResponse(Response.Status.OK, response, resourcePath));
-
-            if (recoveryPasses == 0) {
-                // success, recovery has happened
-                if (resource == null) {
-                    // recovery may still be running for other resources so linger a little longer
-                    Thread.sleep(1000L);
-                }
-
-                return; // recovered successfully
-            }
-
-            LOGGER.info("replayEndPhase: recoveryPasses=" + recoveryPasses);
-
-            Thread.sleep(RECOVERY_CHECK_INTERVAL * 1000); // delay before rechecking for recovery
-            maxWait -= RECOVERY_CHECK_INTERVAL;
-        } while (maxWait > 0L);
-
-        throw new RuntimeException("TckTestBase: recovery was not triggered for resource " + resource);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownStatusTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownStatusTests.java
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.lra.tck.participant.api.LRAUnknownStatusResource
 import org.eclipse.microprofile.lra.tck.participant.api.Scenario;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
+import org.eclipse.microprofile.lra.tck.service.LRATestService;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -49,6 +50,9 @@ public class TckUnknownStatusTests extends TckTestBase {
     @Inject
     private LRAMetricService lraMetricService;
 
+    @Inject
+    private LRATestService lraTestService;
+
     @Deployment(name = "tckunkownstatus")
     public static WebArchive deploy() {
         return TckUnknownStatusTests.deploy(TckUnknownStatusTests.class.getSimpleName().toLowerCase());
@@ -64,7 +68,7 @@ public class TckUnknownStatusTests extends TckTestBase {
         String lraIdString = invoke(Scenario.COMPENSATE_RETRY);
         URI lraId = URI.create(lraIdString);
 
-        applyLongConsistencyDelay();
+        lraTestService.waitForRecovery(lraId);
         int compensated = lraMetricService.getMetric(LRAMetricType.Compensated, lraId);
         int status = lraMetricService.getMetric(LRAMetricType.Status, lraId);
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
@@ -81,7 +85,7 @@ public class TckUnknownStatusTests extends TckTestBase {
         String lraIdString = invoke(Scenario.COMPLETE_RETRY);
         URI lraId = URI.create(lraIdString);
 
-        applyLongConsistencyDelay();
+        lraTestService.waitForRecovery(lraId);
         int completed = lraMetricService.getMetric(LRAMetricType.Completed, lraId);
         int status = lraMetricService.getMetric(LRAMetricType.Status, lraId);
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownTests.java
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.lra.tck.participant.api.LRAUnknownResource;
 import org.eclipse.microprofile.lra.tck.participant.api.Scenario;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
+import org.eclipse.microprofile.lra.tck.service.LRATestService;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -49,6 +50,9 @@ public class TckUnknownTests extends TckTestBase {
     @Inject
     private LRAMetricService lraMetricService;
 
+    @Inject
+    private LRATestService lraTestService;
+
     @Deployment(name = "tckunkown")
     public static WebArchive deploy() {
         return TckTestBase.deploy(TckUnknownTests.class.getSimpleName().toLowerCase());
@@ -64,7 +68,7 @@ public class TckUnknownTests extends TckTestBase {
         String lraIdString = invoke(Scenario.COMPENSATE_IMMEDIATE);
         URI lraId = URI.create(lraIdString);
 
-        applyLongConsistencyDelay();
+        lraTestService.waitForRecovery(lraId);
         int compensated = lraMetricService.getMetric(LRAMetricType.Compensated, lraId);
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int cancelled = lraMetricService.getMetric(LRAMetricType.Cancelled, lraId);
@@ -78,8 +82,9 @@ public class TckUnknownTests extends TckTestBase {
     public void compensate_retry() throws WebApplicationException {
         String lraIdString = invoke(Scenario.COMPENSATE_RETRY);
         URI lraId = URI.create(lraIdString);
-
-        applyLongConsistencyDelay();
+        
+        lraTestService.waitForRecovery(lraId);
+        
         int compensated = lraMetricService.getMetric(LRAMetricType.Compensated, lraId);
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int cancelled = lraMetricService.getMetric(LRAMetricType.Cancelled, lraId);
@@ -94,7 +99,7 @@ public class TckUnknownTests extends TckTestBase {
         String lraIdString = invoke(Scenario.COMPLETE_IMMEDIATE);
         URI lraId = URI.create(lraIdString);
 
-        applyLongConsistencyDelay();
+        lraTestService.waitForRecovery(lraId);
         int completed = lraMetricService.getMetric(LRAMetricType.Completed, lraId);
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int closed = lraMetricService.getMetric(LRAMetricType.Closed, lraId);
@@ -109,7 +114,8 @@ public class TckUnknownTests extends TckTestBase {
         String lraIdString = invoke(Scenario.COMPLETE_RETRY);
         URI lraId = URI.create(lraIdString);
 
-        applyLongConsistencyDelay();
+        lraTestService.waitForRecovery(lraId);
+        
         int completed = lraMetricService.getMetric(LRAMetricType.Completed, lraId);
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int closed = lraMetricService.getMetric(LRAMetricType.Closed, lraId);

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraResource.java
@@ -89,6 +89,7 @@ public class LraResource {
      * participant {@link ParticipantStatus}, or 410 if the participant does no longer know about this LRA.
      *
      * @param lraId the id of the LRA
+     * @param recoveryId the recovery id of this enlistment
      * @return the status of the LRA
      */
     @GET

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/spi/LRACallbackException.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/spi/LRACallbackException.java
@@ -19,24 +19,21 @@
  *******************************************************************************/
 package org.eclipse.microprofile.lra.tck.service.spi;
 
-import java.net.URI;
-
 /**
- * This interface is providing the implementation with the ability to trigger recovery (replay of the Compensate,
- * Complete or Status) calls when the TCK requires to perform such action. This allows to not wait for the periodic
- * recovery and thus it makes the TCK runs faster.
+ * Generic exception for any failures that occures during the invocations of methods in
+ * {@link LRARecoveryService}.
  */
-public interface LraRecoveryService {
+public class LRACallbackException extends Exception {
 
-    /**
-     * Triggers the recovery of all active LRAs in the system.
-     */
-    void triggerRecovery();
+    public LRACallbackException() {
+        super();
+    }
 
-    /**
-     * Triggers the recovery of a single LRA passed as an argument.
-     *
-     * @param lraId the LRA context of the LRA to be recovered
-     */
-    void triggerRecovery(URI lraId);
+    public LRACallbackException(String message) {
+        super(message);
+    }
+
+    public LRACallbackException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/spi/LRARecoveryService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/spi/LRARecoveryService.java
@@ -1,0 +1,85 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.lra.tck.service.spi;
+
+import java.net.URI;
+import java.util.logging.Logger;
+
+/**
+ *     The LRA model guarantees eventual consistency but does not say when
+ *     participants will be brought into a consistent state. When a request
+ *     to close/cancel an LRA is received, the implementation is allowed to
+ *     delay sending out the complete/compensate callbacks (the specification
+ *     only requires that an implementation must eventually send them).
+ *
+ *     This SPI provides a mechanism for an implementation to indicate when
+ *     it knows that callbacks have been sent and responses received or when
+ *     callbacks have been issued, all participants have reached an end state,
+ *     and when all listener notifications have been successfully delivered.
+ *
+ */
+public interface LRARecoveryService {
+
+    /**
+     * Wait for the delivery of Complete and Compensate participant callbacks.
+     * When this method returns the caller can be certain that the callbacks were
+     * sent and responses received (including error responses).
+     *
+     * @param lraId the LRA context
+     * @throws LRACallbackException the implementation was unable to determine whether
+     * or not the callbacks were received by all participants
+     */
+    void waitForCallbacks(URI lraId) throws LRACallbackException;
+
+    /**
+     * Wait for all participants to reach an end state and for all
+     * {@link org.eclipse.microprofile.lra.annotation.AfterLRA} notifications to be successfully delivered.
+     * 
+     * The default implementation iterates {@link LRARecoveryService#waitForEndPhaseReplay(URI)} until
+     * all participants reach a final state and for all listeners notifications to be successfully delivered.
+     *
+     * @param lraId the LRA context
+     * @throws LRACallbackException the implementation was unable to determine whether
+     * or not all participants have reached an end state and whether or not all listeners have been
+     * successfully notified
+     */
+    default void waitForRecovery(URI lraId) throws LRACallbackException {
+        Logger log = Logger.getLogger(LRARecoveryService.class.getName());
+        int counter = 0;
+
+        do {
+            log.info("Recovery attempt #" + ++counter);
+        } while (!waitForEndPhaseReplay(lraId));
+        log.info("LRA " + lraId + "has finished the recovery");
+    }
+
+    /**
+     * Wait for one replay of the end phase of the LRA (the calls to Status, Complete, Compensate, and Forget
+     * methods of all Compensating/Completing participants. If the LRA is finished as a result of this call
+     * all listeners must also be successfully notified before this method returns.
+     * 
+     * @param lraId the LRA context
+     * @return true if after the recovery all participants reached an end state and all AfterLRA listeners were
+     * successfully notified, false otherwise
+     * @throws LRACallbackException the implementation was unable to determine whether
+     * or not the callbacks were received by all participants
+     */
+    boolean waitForEndPhaseReplay(URI lraId) throws LRACallbackException;
+}

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/spi/LRARecoveryService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/spi/LRARecoveryService.java
@@ -50,10 +50,11 @@ public interface LRARecoveryService {
 
     /**
      * Wait for all participants to reach an end state and for all
-     * {@link org.eclipse.microprofile.lra.annotation.AfterLRA} notifications to be successfully delivered.
-     * 
+     * {@link org.eclipse.microprofile.lra.annotation.AfterLRA} notifications to be successfully delivered
+     * (AfterLRA methods return HTTP 200).
+     *
      * The default implementation iterates {@link LRARecoveryService#waitForEndPhaseReplay(URI)} until
-     * all participants reach a final state and for all listeners notifications to be successfully delivered.
+     * all participants reach a final state and all AfterLRA listeners notifications are successfully delivered.
      *
      * @param lraId the LRA context
      * @throws LRACallbackException the implementation was unable to determine whether
@@ -71,15 +72,19 @@ public interface LRARecoveryService {
     }
 
     /**
-     * Wait for one replay of the end phase of the LRA (the calls to Status, Complete, Compensate, and Forget
+     * Wait for one replay of the end phase of the LRA (the callback calls to Status, Complete, Compensate, and Forget
      * methods of all Compensating/Completing participants. If the LRA is finished as a result of this call
-     * all listeners must also be successfully notified before this method returns.
-     * 
+     * all listeners must also be successfully notified before this method returns. The callback calls must be attempted
+     * but do not have to be successful (e.g. implementation tries to call Compensate which returns connection refused
+     * is a valid invocation of this method).
+     *
      * @param lraId the LRA context
-     * @return true if after the recovery all participants reached an end state and all AfterLRA listeners were
-     * successfully notified, false otherwise
-     * @throws LRACallbackException the implementation was unable to determine whether
-     * or not the callbacks were received by all participants
+     * @return true if the implementation successfully issued callback requests and received responses that indicate
+     * that final state was achieved and all AfterLRA listeners were successfully notified (AfterLRA methods returned
+     * HTTP 200), or false if the implementation successfully issued callback requests but it did not receive all
+     * responses or the received responses indicate that the final state is not reached yet
+     * @throws LRACallbackException the implementation has no knowledge of this LRA or it was unable to retry
+     * the requests to all participants so it does not make sense to trigger this method with the same argument again
      */
     boolean waitForEndPhaseReplay(URI lraId) throws LRACallbackException;
 }


### PR DESCRIPTION
Also, clean up unused replayEndPhase recovery handling.

The TckRecoveryTests require that the LRARecoveryService is injectable through the Arquillian resource injection. So it needs to be a CDI bean and be injectable be Arquillian.

resolves #249 

Signed-off-by: xstefank <xstefank122@gmail.com>