### PR TITLE
issue6 TckTests#timeLimitWithPreConditionFailed expected response sho…

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
@@ -353,8 +353,8 @@ public class TckTests extends TckTestBase {
      * Service A calls Service B after it has waited 1 sec.
      * Service A returns http Status from the call to Service B.
      *
-     * test calls A and verifies if return is status 412 (precondition failed) since LRA
-     * is not active when Service B endpoint is called.
+     * test calls A and verifies if return is status 412 (precondition failed)
+     * or 410 (gone) since LRA is not active when Service B endpoint is called.
      */
     @Test
     public void timeLimitWithPreConditionFailed() {
@@ -364,9 +364,10 @@ public class TckTests extends TckTestBase {
                 .get();
 
         // verify that a 412 response code was generated
-        assertEquals("Expected 412 response",
-                Response.Status.PRECONDITION_FAILED.getStatusCode(),
-                response.getStatus());
+        assertTrue("Expected 412 or 410 response",
+                response.getStatus() == Response.Status.PRECONDITION_FAILED.getStatusCode() ||
+                        response.getStatus() == Response.Status.GONE.getStatusCode()
+                );
 
         response.close();
     }


### PR DESCRIPTION
…uld be GONE or PRECONDITION_FAILED

This PR fixes a bug in the test added during PR #267 
The test timeLimitWithPreConditionFailed starts an LRA, waits for it to time out and then invokes another method that should cause another enlistment. Since the LRA will have timed out, the second call should fail with either 412 or 410 but the test only checks for 412.