### PR TITLE
#275 Fix tests that wrongly assume callbacks are delivered with "exac…

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/LRAClientOps.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/LRAClientOps.java
@@ -108,13 +108,13 @@ public class LRAClientOps {
      * @return the end status of the LRA (or null if the LRA has not yet finished)
      */
     private LRAStatus getLRAEndStatus(URI lra, LRAMetricService lraMetricService, String resourceName) {
-        if (lraMetricService.getMetric(LRAMetricType.Closed, lra, resourceName) == 1) {
+        if (lraMetricService.getMetric(LRAMetricType.Closed, lra, resourceName) >= 1) {
             return LRAStatus.Closed;
-        } else if (lraMetricService.getMetric(LRAMetricType.FailedToClose, lra, resourceName) == 1) {
+        } else if (lraMetricService.getMetric(LRAMetricType.FailedToClose, lra, resourceName) >= 1) {
             return LRAStatus.FailedToClose;
-        } else if (lraMetricService.getMetric(LRAMetricType.Cancelled, lra, resourceName) == 1) {
+        } else if (lraMetricService.getMetric(LRAMetricType.Cancelled, lra, resourceName) >= 1) {
             return LRAStatus.Cancelled;
-        } else if (lraMetricService.getMetric(LRAMetricType.FailedToCancel, lra, resourceName) == 1) {
+        } else if (lraMetricService.getMetric(LRAMetricType.FailedToCancel, lra, resourceName) >= 1) {
             return LRAStatus.FailedToCancel;
         }
 

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckCancelOnTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckCancelOnTests.java
@@ -38,6 +38,7 @@ import java.net.URI;
 
 import static org.eclipse.microprofile.lra.tck.participant.api.LraCancelOnResource.LRA_CANCEL_ON_RESOURCE_PATH;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
 public class TckCancelOnTests extends TckTestBase {
@@ -69,8 +70,8 @@ public class TckCancelOnTests extends TckTestBase {
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.BAD_REQUEST, response, resourcePath));
         lraTestService.waitForCallbacks(lraId);
-        assertEquals("After 400 compensate should be invoked", 
-            1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
+        assertTrue("After 400 compensate should be invoked",
+            lraMetricService.getMetric(LRAMetricType.Compensated, lraId) >= 1);
         assertEquals("After 400 complete can't be invoked", 
             0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }
@@ -87,8 +88,8 @@ public class TckCancelOnTests extends TckTestBase {
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.INTERNAL_SERVER_ERROR, response, resourcePath));
         lraTestService.waitForCallbacks(lraId);
-        assertEquals("After 500 compensate should be invoked", 
-            1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
+        assertTrue("After 500 compensate should be invoked",
+            lraMetricService.getMetric(LRAMetricType.Compensated, lraId) >= 1);
         assertEquals("After 500 complete can't be invoked", 
             0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }
@@ -105,8 +106,8 @@ public class TckCancelOnTests extends TckTestBase {
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.SEE_OTHER, response, resourcePath));
         lraTestService.waitForCallbacks(lraId);
-        assertEquals("After status code 303 is received, compensate should be invoked as set by attribute cancelOnFamily",
-                1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
+        assertTrue("After status code 303 is received, compensate should be invoked as set by attribute cancelOnFamily",
+                lraMetricService.getMetric(LRAMetricType.Compensated, lraId) >= 1);
         assertEquals("After status code 303 is received, complete can't be invoked as not defined in annotation @LRA",
                 0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }
@@ -123,8 +124,8 @@ public class TckCancelOnTests extends TckTestBase {
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.MOVED_PERMANENTLY, response, resourcePath));
         lraTestService.waitForCallbacks(lraId);
-        assertEquals("After status code 301 is received, compensate should be invoked as set by attribute cancelOn",
-                1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
+        assertTrue("After status code 301 is received, compensate should be invoked as set by attribute cancelOn",
+                lraMetricService.getMetric(LRAMetricType.Compensated, lraId) >= 1);
         assertEquals("After status code 301 is received, complete can't be invoked as not defined in annotation @LRA",
                 0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }
@@ -143,8 +144,8 @@ public class TckCancelOnTests extends TckTestBase {
         lraTestService.waitForCallbacks(lraId);
         assertEquals("After status code 500 is received, compensate can't be invoked as default behaviour was changed",
                 0, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
-        assertEquals("After status code 500 is received, complete has to be called as default behaviour was changed",
-                1, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
+        assertTrue("After status code 500 is received, complete has to be called as default behaviour was changed",
+                lraMetricService.getMetric(LRAMetricType.Completed, lraId) >= 1);
     }
 
     /**
@@ -159,9 +160,8 @@ public class TckCancelOnTests extends TckTestBase {
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Status.OK, response, resourcePath));
         lraTestService.waitForCallbacks(lraId);
-        // LraCancelOnResource enlists twice the same participant, compensate is expected to be called only once
-        assertEquals("Status was 200 but compensate should be called as LRA should be cancelled for remotely called participant as well",
-                1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
+        assertTrue("Status was 200 but compensate should be called as LRA should be cancelled for remotely called participant as well",
+                lraMetricService.getMetric(LRAMetricType.Compensated, lraId) >= 1);
         assertEquals("Even the 200 status was received the remotely called participant should cause the LRA being cancelled",
                 0, lraMetricService.getMetric(LRAMetricType.Completed, lraId));
     }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
@@ -169,11 +169,11 @@ public class TckContextTests extends TckTestBase {
         // the implementation should have called status again which will have returned 200
         count = lraMetricService.getMetric(LRAMetricType.Status, lra);
         // the implementation should have called status at least once. Since we have alread called status in this test
-        // check that the stat is at least 2
+        // check that the status count is at least 2
         assertTrue(testName.getMethodName() + " resource status should have been called again", count >= 2);
         // the implementation should call forget since it knows the participant status
         count = lraMetricService.getMetric(LRAMetricType.Forget, lra);
-        assertEquals(testName.getMethodName() + " resource forget should have been called", 1, count);
+        assertTrue(testName.getMethodName() + " resource forget should have been called", count >= 1);
     }
 
     /*
@@ -327,8 +327,8 @@ public class TckContextTests extends TckTestBase {
             lraMetricService.getMetric(LRAMetricType.Completed, lra));
 
         // and that afterLRA listener was notified
-        assertEquals("AfterLRA listener registered during the Closing phase was not notified about the LRA close",
-            1, lraMetricService.getMetric(LRAMetricType.Closed, lra, AfterLRAListener.class.getName()));
+        assertTrue("AfterLRA listener registered during the Closing phase was not notified about the LRA close",
+            lraMetricService.getMetric(LRAMetricType.Closed, lra, AfterLRAListener.class.getName()) >= 1);
     }
 
     private String invoke(String where, HttpMethod method, URI lraContext) {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckParticipantTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckParticipantTests.java
@@ -116,10 +116,10 @@ public class TckParticipantTests extends TckTestBase {
 
         lraTestService.waitForRecovery(lraId);
 
-        assertEquals("Non JAX-RS @Status method should have been called", 
-            1, lraMetricService.getMetric(LRAMetricType.Status, lraId));
-        assertEquals("Non JAX-RS @Forget method should have been called",
-            1, lraMetricService.getMetric(LRAMetricType.Forget, lraId));
+        assertTrue("Non JAX-RS @Status method should have been called", 
+            lraMetricService.getMetric(LRAMetricType.Status, lraId) >= 1);
+        assertTrue("Non JAX-RS @Forget method should have been called",
+            lraMetricService.getMetric(LRAMetricType.Forget, lraId) >= 1);
 
     }
 
@@ -167,8 +167,8 @@ public class TckParticipantTests extends TckTestBase {
 
         lraTestService.waitForRecovery(lraId);
 
-        assertEquals("Non JAX-RS @Status method with CompletionStage<ParticipantStatus> should have been called",
-            1, lraMetricService.getMetric(LRAMetricType.Status, lraId));
+        assertTrue("Non JAX-RS @Status method with CompletionStage<ParticipantStatus> should have been called",
+            lraMetricService.getMetric(LRAMetricType.Status, lraId) >= 1);
         
         lraTestService.waitForRecovery(lraId);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownStatusTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownStatusTests.java
@@ -75,7 +75,7 @@ public class TckUnknownStatusTests extends TckTestBase {
         int cancelled = lraMetricService.getMetric(LRAMetricType.Cancelled, lraId);
 
         assertEquals("Number of calls to @Compensate incorrect",1, compensated);
-        assertEquals("Number of calls to @Status incorrect",1, status);
+        assertTrue("Number of calls to @Status incorrect", status >= 1);
         assertTrue("Number of calls to @AfterLRA incorrect", afterLRA >= 1);
         assertTrue("Final LRA status of Cancelled incorrect", cancelled >= 1);
     }
@@ -92,7 +92,7 @@ public class TckUnknownStatusTests extends TckTestBase {
         int closed = lraMetricService.getMetric(LRAMetricType.Closed, lraId);
 
         assertEquals("Number of calls to @Complete incorrect",1, completed);
-        assertEquals("Number of calls to @Status incorrect",1, status);
+        assertTrue("Number of calls to @Status incorrect", status >= 1);
         assertTrue("Number of calls to @AfterLRA incorrect", afterLRA >= 1);
         assertTrue("Final LRA status of Closed incorrect", closed >= 1);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownTests.java
@@ -38,7 +38,6 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -73,7 +72,7 @@ public class TckUnknownTests extends TckTestBase {
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int cancelled = lraMetricService.getMetric(LRAMetricType.Cancelled, lraId);
 
-        assertEquals("Number of calls to @Compensate incorrect", 1, compensated);
+        assertTrue("Number of calls to @Compensate incorrect", compensated >= 1);
         assertTrue("Number of calls to @AfterLRA incorrect", afterLRA >= 1);
         assertTrue("Final LRA status of Cancelled incorrect", cancelled >= 1);
     }
@@ -89,7 +88,7 @@ public class TckUnknownTests extends TckTestBase {
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int cancelled = lraMetricService.getMetric(LRAMetricType.Cancelled, lraId);
 
-        assertEquals("Number of calls to @Compensate incorrect", 2, compensated);
+        assertTrue("Number of calls to @Compensate incorrect", compensated >= 2);
         assertTrue("Number of calls to @AfterLRA incorrect", afterLRA >= 1);
         assertTrue("Final LRA status of Cancelled incorrect", cancelled >= 1);
     }
@@ -104,7 +103,7 @@ public class TckUnknownTests extends TckTestBase {
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int closed = lraMetricService.getMetric(LRAMetricType.Closed, lraId);
 
-        assertEquals("Number of calls to @Complete incorrect", 1, completed);
+        assertTrue("Number of calls to @Complete incorrect", completed >= 1);
         assertTrue("Number of calls to @AfterLRA incorrect", afterLRA >= 1);
         assertTrue("Final LRA status of Closed incorrect",closed >= 1);
     }
@@ -120,7 +119,7 @@ public class TckUnknownTests extends TckTestBase {
         int afterLRA = lraMetricService.getMetric(LRAMetricType.AfterLRA, lraId);
         int closed = lraMetricService.getMetric(LRAMetricType.Closed, lraId);
 
-        assertEquals("Number of calls to @Complete incorrect", 2, completed);
+        assertTrue("Number of calls to @Complete incorrect", completed >= 2);
         assertTrue("Number of calls to @AfterLRA incorrect", afterLRA >= 1);
         assertTrue("Final LRA status of Closed incorrect",closed >= 1);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/RecoveryResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/RecoveryResource.java
@@ -99,13 +99,13 @@ public class RecoveryResource {
 
         // assert compensate has been called
         int compensations = lraMetricService.getMetric(LRAMetricType.Compensated, lraId, RecoveryResource.class.getName());
-        if (compensations != 1) {
+        if (compensations < 1) {
             return assertFailedResponse("Compensate on restarted service should have been called. Was " + compensations);
         }
 
         // assert after LRA has been called
         int afterLRACalls = lraMetricService.getMetric(LRAMetricType.Cancelled, lraId, RecoveryResource.class.getName());
-        if (afterLRACalls != 1) {
+        if (afterLRACalls < 1) {
             return assertFailedResponse("After LRA with Cancelled status should have been called. Was " + afterLRACalls);
         }
 


### PR DESCRIPTION
…tly once" semantics

resolves #275 

Changes:
* Complete/Compensate to "at least once" where there is no Status method in the resource
  * otherwise keep exactly-once semantics, we probably need to cover how the implementation should behave if there is the Status method and Complete/Compensate call fails (this will also require spec text changes so I will open a new issue - https://github.com/eclipse/microprofile-lra/issues/283)
* AfterLRA, Forget, Status to "at least once"

Signed-off-by: xstefank <xstefank122@gmail.com>