### PR TITLE
Fix unclear indication about participant resource holding

### DIFF
--- a/spec/src/main/asciidoc/microprofile-lra-spec.adoc
+++ b/spec/src/main/asciidoc/microprofile-lra-spec.adoc
@@ -1152,7 +1152,8 @@ If the participant has already responded successfully to an `@Compensate`
 or `@Complete` method invocation then it MAY report `410 Gone`
 HTTP status code or in the case of non-JAX-RS method returning
 <<source-ParticipantStatus,ParticipantStatus>> `null`.
-This enables the participant to free up resources.
+This enables the participant to free up resources if it
+hasn't done so previously.
 
 [[forgetting-an-lra]]
 ==== Forgetting an LRA


### PR DESCRIPTION
No issue needed.

It was pointed in [this comment](https://github.com/eclipse/microprofile-lra/issues/283#issuecomment-599450451) that the last sentence of the Status paragraph is ambiguous.

Signed-off-by: xstefank <xstefank122@gmail.com>