### PR TITLE
Use ArquillianResource instead of lra.tck.base.url

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/LraTckConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/LraTckConfigBean.java
@@ -62,7 +62,4 @@ public class LraTckConfigBean {
         return timeoutFactor;
     }
 
-    public String tckSuiteBaseUrl() {
-        return tckSuiteBaseUrl;
-    }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckCancelOnTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckCancelOnTests.java
@@ -148,7 +148,7 @@ public class TckCancelOnTests extends TckTestBase {
     }
 
     /**
-     * See {@link LraCancelOnResource#cancelFromRemoteCall(java.net.URI)}
+     * See {@link LraCancelOnResource#cancelFromRemoteCall(java.net.URI, javax.ws.rs.core.UriInfo)}
      */
     @Test
     public void cancelFromRemoteCall() {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTestBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTestBase.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.lra.tck.participant.api.LraResource;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
 import org.eclipse.microprofile.lra.tck.service.LRATestService;
 import org.eclipse.microprofile.lra.tck.service.spi.LRARecoveryService;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -35,6 +36,8 @@ import org.junit.rules.TestName;
 import javax.inject.Inject;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
+
+import java.net.URL;
 import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
@@ -49,6 +52,9 @@ public class TckTestBase {
     
     @Inject
     private LRATestService lraTestService;
+    
+    @ArquillianResource
+    private URL deploymentURL;
 
     LRAClientOps lraClient;
 
@@ -74,7 +80,7 @@ public class TckTestBase {
     public void before() {
         LOGGER.info("Running test: " + testName.getMethodName());
         
-        lraTestService.start();
+        lraTestService.start(deploymentURL);
         this.lraClient = lraTestService.getLRAClient();
         this.tckSuiteTarget = lraTestService.getTCKSuiteTarget();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/RecoveryResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/RecoveryResource.java
@@ -27,8 +27,6 @@ import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
 import org.eclipse.microprofile.lra.tck.service.LRATestService;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.DefaultValue;
@@ -62,16 +60,6 @@ public class RecoveryResource {
 
     @Inject
     LRATestService lraTestService;
-
-    @PostConstruct
-    public void postConstruct() {
-        lraTestService.start();
-    }
-
-    @PreDestroy
-    public void preDestroy() {
-        lraTestService.stop();
-    }
 
     /**
      * Starts a new LRA and enlists an instance of this class with it as a participant

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRATestService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRATestService.java
@@ -30,7 +30,6 @@ import javax.inject.Inject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.Iterator;
@@ -53,16 +52,11 @@ public class LRATestService {
 
     private LRARecoveryService lraRecoveryService = loadService(LRARecoveryService.class);
 
-    public void start() {
+    public void start(URL deploymentURL) {
         tckSuiteClient = ClientBuilder.newClient();
         lraMetricService.clear();
-
-        try {
-            tckSuiteTarget = tckSuiteClient.target(URI.create(new URL(config.tckSuiteBaseUrl()).toExternalForm()));
-            lraClient = new LRAClientOps(tckSuiteTarget);
-        } catch (MalformedURLException mfe) {
-            throw new IllegalStateException("Cannot create URL for the LRA TCK suite base url " + config.tckSuiteBaseUrl(), mfe);
-        }
+        tckSuiteTarget = tckSuiteClient.target(URI.create(deploymentURL.toExternalForm()));
+        lraClient = new LRAClientOps(tckSuiteTarget);
     }
 
     public void stop() {


### PR DESCRIPTION
For app servers which don't deploy the arquillian tests to the same
context root each time, the base url will change for every test.
Hence for these app servers (such as Open Liberty), setting a single
base url property is unreliable.

Signed-off-by: ilewis <ilewis@uk.ibm.com>