### PR TITLE
Fix TckRecoveryTests deployment URL handling

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckRecoveryTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckRecoveryTests.java
@@ -56,6 +56,8 @@ import java.util.logging.Logger;
  */
 @RunWith(Arquillian.class)
 public class TckRecoveryTests {
+    
+    public static final String LRA_TCK_DEPLOYMENT_URL = "LRA-TCK-Deployment-URL";
 
     private static final String DEPLOYMENT_NAME = "tck-recovery";
     private static final Logger LOGGER = Logger.getLogger(TckRecoveryTests.class.getName());
@@ -111,8 +113,12 @@ public class TckRecoveryTests {
         deployer.deploy(DEPLOYMENT_NAME);
         
         // invoke phase 1 inside the container (start new LRA and enlist resource)
-        Response response1 = deploymentTarget.path(RecoveryResource.RECOVERY_RESOURCE_PATH)
-            .path(RecoveryResource.PHASE_1).request().get();
+        Response response1 = deploymentTarget
+            .path(RecoveryResource.RECOVERY_RESOURCE_PATH)
+            .path(RecoveryResource.PHASE_1)
+            .request()
+            .header(LRA_TCK_DEPLOYMENT_URL, deploymentURL.toExternalForm())
+            .get();
         
         Assert.assertEquals(200, response1.getStatus());
         URI lra = URI.create(response1.readEntity(String.class));
@@ -129,6 +135,7 @@ public class TckRecoveryTests {
             .path(RecoveryResource.PHASE_2)
             .request()
                 .header(RecoveryResource.LRA_HEADER, lra)
+                .header(LRA_TCK_DEPLOYMENT_URL, deploymentURL.toExternalForm())
                 .get();
         
         Assert.assertEquals(response2.readEntity(String.class), 200, response2.getStatus());
@@ -160,7 +167,9 @@ public class TckRecoveryTests {
         Response response1 = deploymentTarget.path(RecoveryResource.RECOVERY_RESOURCE_PATH)
             .path(RecoveryResource.PHASE_1)
             .queryParam("timeout", true)
-            .request().get();
+            .request()
+            .header(LRA_TCK_DEPLOYMENT_URL, deploymentURL.toExternalForm())
+            .get();
 
         Assert.assertEquals(200, response1.getStatus());
         URI lra = URI.create(response1.readEntity(String.class));
@@ -192,6 +201,7 @@ public class TckRecoveryTests {
             .path(RecoveryResource.TRIGGER_RECOVERY)
             .request()
                 .header(RecoveryResource.LRA_HEADER, lra)
+                .header(LRA_TCK_DEPLOYMENT_URL, deploymentURL.toExternalForm())
                 .get();
 
         // invoke phase 2 inside the container (execute checks that verify that callbacks have been called)
@@ -199,6 +209,7 @@ public class TckRecoveryTests {
             .path(RecoveryResource.PHASE_2)
             .request()
                 .header(RecoveryResource.LRA_HEADER, lra)
+                .header(LRA_TCK_DEPLOYMENT_URL, deploymentURL.toExternalForm())
                 .get();
 
         Assert.assertEquals(response2.readEntity(String.class), 200, response2.getStatus());

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTestBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTestBase.java
@@ -52,6 +52,9 @@ public class TckTestBase {
     
     @Inject
     private LRATestService lraTestService;
+
+    @Inject
+    private LRAMetricService lraMetricService;
     
     @ArquillianResource
     private URL deploymentURL;
@@ -81,6 +84,7 @@ public class TckTestBase {
         LOGGER.info("Running test: " + testName.getMethodName());
         
         lraTestService.start(deploymentURL);
+        lraMetricService.clear();
         this.lraClient = lraTestService.getLRAClient();
         this.tckSuiteTarget = lraTestService.getTCKSuiteTarget();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/RecoveryResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/RecoveryResource.java
@@ -23,6 +23,7 @@ import org.eclipse.microprofile.lra.annotation.AfterLRA;
 import org.eclipse.microprofile.lra.annotation.Compensate;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.eclipse.microprofile.lra.tck.TckRecoveryTests;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
 import org.eclipse.microprofile.lra.tck.service.LRATestService;
@@ -38,6 +39,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import java.net.URI;
+import java.net.URL;
 import java.time.temporal.ChronoUnit;
 
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
@@ -69,11 +71,16 @@ public class RecoveryResource {
      */
     @GET
     @Path(PHASE_1)
-    public Response phase1(@QueryParam("timeout") @DefaultValue("false") boolean timeout) {
+    public Response phase1(@QueryParam("timeout") @DefaultValue("false") boolean timeout,
+                           @HeaderParam(TckRecoveryTests.LRA_TCK_DEPLOYMENT_URL) URL deploymentURL) {
+        
+        lraTestService.start(deploymentURL);
+        
         // start a new LRA and join it with this resource
         URI lra;
         Response response;
         
+
         response = lraTestService.getTCKSuiteTarget().path(RecoveryResource.RECOVERY_RESOURCE_PATH)
                 .path(timeout ? RecoveryResource.REQUIRED_TIMEOUT_PATH : RecoveryResource.REQUIRED_PATH)
                 .request().put(Entity.text(""));
@@ -93,7 +100,9 @@ public class RecoveryResource {
      */
     @GET
     @Path(PHASE_2)
-    public Response phase2(@HeaderParam(LRA_HEADER) URI lraId) {
+    public Response phase2(@HeaderParam(LRA_HEADER) URI lraId,
+                           @HeaderParam(TckRecoveryTests.LRA_TCK_DEPLOYMENT_URL) URL deploymentURL) {
+        lraTestService.start(deploymentURL);
         lraTestService.getLRAClient().cancelLRA(lraId);
         lraTestService.waitForCallbacks(lraId);
 
@@ -118,7 +127,9 @@ public class RecoveryResource {
 
     @GET
     @Path(TRIGGER_RECOVERY)
-    public Response triggerRecovery(@HeaderParam(LRA_HEADER) URI lraId) {
+    public Response triggerRecovery(@HeaderParam(LRA_HEADER) URI lraId,
+                                    @HeaderParam(TckRecoveryTests.LRA_TCK_DEPLOYMENT_URL) URL deploymentURL) {
+        lraTestService.start(deploymentURL);
         lraTestService.waitForRecovery(lraId);
         return Response.ok().build();
     } 

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRATestService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRATestService.java
@@ -39,9 +39,6 @@ import java.util.ServiceLoader;
 public class LRATestService {
 
     @Inject
-    LRAMetricService lraMetricService;
-    
-    @Inject
     LraTckConfigBean config;
 
     private LRAClientOps lraClient;
@@ -54,7 +51,6 @@ public class LRATestService {
 
     public void start(URL deploymentURL) {
         tckSuiteClient = ClientBuilder.newClient();
-        lraMetricService.clear();
         tckSuiteTarget = tckSuiteClient.target(URI.create(deploymentURL.toExternalForm()));
         lraClient = new LRAClientOps(tckSuiteTarget);
     }


### PR DESCRIPTION
With deployment URL handling reworked in #291 the deployment URL is taken now as an Arquillian resource not from the MP config. The issue in TckRecoveryTests is that the deployments are not managed by arquillian and thus the deployment URL is not injected. This fix passes the deployment URL as a header to invocations in the individual phases that are run in the manually started containers (deployments not managed by arquillian).