### PR TITLE
Update release plugin to push changes on release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
                     <version>2.5.3</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <pushChanges>false</pushChanges>
+                        <pushChanges>true</pushChanges>
                         <localCheckout>true</localCheckout>
                         <useReleaseProfile>false</useReleaseProfile>
                         <arguments>${arguments} -Prelease -Drevremark=${revremark}</arguments>


### PR DESCRIPTION
I managed to perform 1.0-M1 release yesterday (after some issues with CI). I noticed that our job didn't push the created tag to github so after some debugging of Jenkins outputs from other jobs I think that this could be the issue, however, not 100% on that as I don't have experience in this regard. It seems that this could help so when we'll perform next release I'll try to remember to keep an eye on tag creation.