### PR TITLE
#305 Add a TCK test which ensures compensate may called before the participant's business method finishes. 

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckParticipantTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckParticipantTests.java
@@ -19,6 +19,25 @@
  *******************************************************************************/
 package org.eclipse.microprofile.lra.tck;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.logging.Logger;
+
+import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.eclipse.microprofile.lra.tck.participant.nonjaxrs.valid.LongBusinessMethodParticipant;
 import org.eclipse.microprofile.lra.tck.participant.nonjaxrs.valid.ValidLRACSParticipant;
 import org.eclipse.microprofile.lra.tck.participant.nonjaxrs.valid.ValidLRAParticipant;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
@@ -27,26 +46,18 @@ import org.eclipse.microprofile.lra.tck.service.LRATestService;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.inject.Inject;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Response;
-
-import java.net.URI;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * TCK to verify that valid non-JAX-RS participant method signatures are respected
  */
 @RunWith(Arquillian.class)
 public class TckParticipantTests extends TckTestBase {
-    
+
     private static final String VALID_DEPLOYMENT = "valid-deploy";
+    private static final Logger LOGGER = Logger.getLogger(TckParticipantTests.class.getName());
 
     @Inject
     private LRAMetricService lraMetricService;
@@ -59,18 +70,18 @@ public class TckParticipantTests extends TckTestBase {
         return TckTestBase.deploy(VALID_DEPLOYMENT)
             .addPackage(ValidLRAParticipant.class.getPackage());
     }
-    
+
     /**
      * Test verifies that non-JAX-RS @Complete method is invoked according to the
      * LRA protocol and that if {@link WebApplicationException} is
-     * thrown inside of a non-JAX-RS participant method than {@link Response} it 
+     * thrown inside of a non-JAX-RS participant method than {@link Response} it
      * is carrying is extracted and acted upon according to LRA response handling
      */
     @Test
     public void validWebApplicationExceptionReturnedTest() {
         WebTarget resourcePath = tckSuiteTarget.path(ValidLRAParticipant.RESOURCE_PATH)
             .path(ValidLRAParticipant.ENLIST_WITH_COMPLETE);
-        
+
         Response response = resourcePath.request().get();
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Response.Status.OK, response, resourcePath));
 
@@ -89,13 +100,13 @@ public class TckParticipantTests extends TckTestBase {
     }
 
     /**
-     * This test verifies chained call of non-JAX-RS participant methods. First 
+     * This test verifies chained call of non-JAX-RS participant methods. First
      * it starts and cancels a new LRA. @Compensate non-JAX-RS method then returns
-     * {@link org.eclipse.microprofile.lra.annotation.ParticipantStatus#Compensating} 
-     * (see {@link ValidLRAParticipant}) indicating that non-JAX-RS @Status method should 
-     * be invoked. The test then waits for recovery and then verifies that @Status method is 
-     * called. This method finishes compensation with return of the {@link Response} object 
-     * indicating failure and so the test then verifies that non-JAX-RS @Forget method has 
+     * {@link org.eclipse.microprofile.lra.annotation.ParticipantStatus#Compensating}
+     * (see {@link ValidLRAParticipant}) indicating that non-JAX-RS @Status method should
+     * be invoked. The test then waits for recovery and then verifies that @Status method is
+     * called. This method finishes compensation with return of the {@link Response} object
+     * indicating failure and so the test then verifies that non-JAX-RS @Forget method has
      * also been called.
      *
      * @throws InterruptedException When Test is interrupted during sleep.
@@ -104,11 +115,11 @@ public class TckParticipantTests extends TckTestBase {
     public void validSignaturesChainTest() throws InterruptedException {
         WebTarget resourcePath = tckSuiteTarget.path(ValidLRAParticipant.RESOURCE_PATH)
             .path(ValidLRAParticipant.ENLIST_WITH_COMPENSATE);
-        
+
         Response response = resourcePath.request().get();
 
         URI lraId = URI.create(checkStatusReadAndCloseResponse(Response.Status.INTERNAL_SERVER_ERROR, response, resourcePath));
-        
+
         assertEquals("Non JAX-RS @Compensate method should have been called",
             1, lraMetricService.getMetric(LRAMetricType.Compensated, lraId));
         assertEquals("@Complete method should not have been called as LRA compensated",
@@ -116,7 +127,7 @@ public class TckParticipantTests extends TckTestBase {
 
         lraTestService.waitForRecovery(lraId);
 
-        assertTrue("Non JAX-RS @Status method should have been called", 
+        assertTrue("Non JAX-RS @Status method should have been called",
             lraMetricService.getMetric(LRAMetricType.Status, lraId) >= 1);
         assertTrue("Non JAX-RS @Forget method should have been called",
             lraMetricService.getMetric(LRAMetricType.Forget, lraId) >= 1);
@@ -124,7 +135,7 @@ public class TckParticipantTests extends TckTestBase {
     }
 
     /**
-     * Test verifies {@link java.util.concurrent.CompletionStage} parametrized with 
+     * Test verifies {@link java.util.concurrent.CompletionStage} parametrized with
      * {@link Void} as valid non-JAX-RS participant method return type
      */
     @Test
@@ -145,7 +156,7 @@ public class TckParticipantTests extends TckTestBase {
     }
 
     /**
-     * Test verifyies {@link java.util.concurrent.CompletionStage} parametrized by 
+     * Test verifyies {@link java.util.concurrent.CompletionStage} parametrized by
      * {@link Response} and {@link org.eclipse.microprofile.lra.annotation.ParticipantStatus} as valid
      * non-JAX-RS participant methods return types
      *
@@ -169,7 +180,43 @@ public class TckParticipantTests extends TckTestBase {
 
         assertTrue("Non JAX-RS @Status method with CompletionStage<ParticipantStatus> should have been called",
             lraMetricService.getMetric(LRAMetricType.Status, lraId) >= 1);
-        
+
         lraTestService.waitForRecovery(lraId);
+    }
+
+    @Test
+    public void cancelLraDuringBusinessMethod() throws InterruptedException, ExecutionException, TimeoutException {
+        LRAClientOps lraOps = lraTestService.getLRAClient();
+        URI lraId = lraOps.startLRA(null, lraClientId(), 0L, ChronoUnit.MILLIS);
+        LOGGER.info(String.format("Started LRA with URI %s", lraId));
+        // Start business method asynchronously, i.e. return immediately.
+        Future<Response> lraFuture = tckSuiteTarget.path(LongBusinessMethodParticipant.ROOT_PATH)
+                .path(LongBusinessMethodParticipant.BUSINESS_METHOD)
+                .request()
+                .header(LRA.LRA_HTTP_CONTEXT_HEADER, lraId)
+                .async()
+                .put(Entity.text(""));
+
+        // Make sure that when we cancel the LRA, the participant is waiting in the business method.
+        Response syncMethodResponse = tckSuiteTarget.path(LongBusinessMethodParticipant.ROOT_PATH)
+                      .path(LongBusinessMethodParticipant.SYNC_METHOD)
+                      .request()
+                      .put(Entity.text(""));
+        Assert.assertEquals(200, syncMethodResponse.getStatus());
+        // -1 indicates that the LRAMetricType.Compensated key is not yet present in the metrics Map.
+        // This in turn means that @Compensate could not have been called yet.
+        Assert.assertEquals(-1, lraMetricService.getMetric(
+                LRAMetricType.Compensated, lraId, LongBusinessMethodParticipant.class.getName()));
+        LOGGER.info(String.format("Cancelled LRA with URI %s", lraId));
+        lraOps.cancelLRA(lraId);
+        // waiting for the LRA to be finished
+        lraTestService.waitForRecovery(lraId);
+        // participant has to be compensated
+        Assert.assertTrue("@Compensate method should have been called at least once.",
+                lraMetricService.getMetric(LRAMetricType.Compensated, lraId, LongBusinessMethodParticipant.class.getName()) >= 1);
+
+        Response response = lraFuture.get(lraTimeout(), TimeUnit.MILLISECONDS);
+        Assert.assertEquals(LongBusinessMethodParticipant.class.getSimpleName() + "'s business method is expected " +
+                "to finish successfully despite the delay.", 200, response.getStatus());
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/nonjaxrs/valid/LongBusinessMethodParticipant.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/nonjaxrs/valid/LongBusinessMethodParticipant.java
@@ -1,0 +1,89 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.lra.tck.participant.nonjaxrs.valid;
+
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Logger;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.lra.annotation.Compensate;
+import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
+import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
+import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
+
+@ApplicationScoped
+@Path(LongBusinessMethodParticipant.ROOT_PATH)
+public class LongBusinessMethodParticipant {
+
+    public static final String ROOT_PATH = "long-business-participant";
+    public static final String BUSINESS_METHOD = "business-method";
+    public static final String SYNC_METHOD = "sync-method";
+
+    private static final Logger LOGGER = Logger.getLogger(LongBusinessMethodParticipant.class.getName());
+
+    private CountDownLatch businessLatch = new CountDownLatch(1);
+    private CountDownLatch syncLatch = new CountDownLatch(1);
+
+    @Inject
+    private LRAMetricService lraMetricService;
+
+    @Compensate
+    public void compensate(URI lraId) {
+        assert lraId != null;
+        if(businessLatch.getCount() > 0) {
+            businessLatch.countDown();
+        }
+        lraMetricService.incrementMetric(LRAMetricType.Compensated, lraId, LongBusinessMethodParticipant.class.getName());
+    }
+
+    @PUT
+    @Path(BUSINESS_METHOD)
+    @LRA(value = LRA.Type.MANDATORY)
+    public Response enlistWithLongLatency(@HeaderParam(LRA.LRA_HTTP_CONTEXT_HEADER) URI lraId) {
+        LOGGER.info("call of enlistWithLongLatency");
+        try {
+            syncLatch.countDown();
+            // await for compensation
+            businessLatch.await();
+            return Response.ok(lraId).build();
+        } catch (InterruptedException ex) {
+            return Response.serverError().build();
+        }
+    }
+
+    @PUT
+    @Path(SYNC_METHOD)
+    public Response sync() {
+        LOGGER.info("call of sync method");
+        try {
+            syncLatch.await();
+        } catch (Exception e) {
+            throw new IllegalStateException("Expecting the latch will be succesfully released on long latency LRA is in progress");
+        }
+        return Response.ok().build();
+    }
+}


### PR DESCRIPTION
resolves #305

   - add a new TCK test (as described in the title) `TckParticipantTests#cancelLraDuringBusinessMethod` and an auxiliary participant `LongBusinessMethodParticipant` used in this test.