### PR TITLE
[294] refactor TCK tests to define in-container tests and run-as-client ones

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckParticipantTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckParticipantTests.java
@@ -126,6 +126,8 @@ public class TckParticipantTests extends TckTestBase {
     /**
      * Test verifies {@link java.util.concurrent.CompletionStage} parametrized with 
      * {@link Void} as valid non-JAX-RS participant method return type
+     *
+     * @throws InterruptedException when waiting for the finishing the completion is interrupted
      */
     @Test
     public void testNonJaxRsCompletionStageVoid() throws InterruptedException {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTestBase.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTestBase.java
@@ -42,6 +42,10 @@ import java.util.logging.Logger;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Base testsuite class for in-container tests.
+ * It provides {@link Before} and @{@link After} junit hooks to clean the environment.
+ */
 public class TckTestBase {
     private static final Logger LOGGER = Logger.getLogger(TckTestBase.class.getName());
 
@@ -73,20 +77,20 @@ public class TckTestBase {
                 LRARecoveryService.class.getPackage())
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
-    
-    @After
-    public void after() {
-        lraTestService.stop();
-    }
 
     @Before
     public void before() {
         LOGGER.info("Running test: " + testName.getMethodName());
-        
+
         lraTestService.start(deploymentURL);
         lraMetricService.clear();
         this.lraClient = lraTestService.getLRAClient();
         this.tckSuiteTarget = lraTestService.getTCKSuiteTarget();
+    }
+
+    @After
+    public void after() {
+        lraTestService.stop();
     }
 
     void checkStatusAndCloseResponse(Response.Status expectedStatus, Response response, WebTarget resourcePath) {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
@@ -22,8 +22,8 @@ package org.eclipse.microprofile.lra.tck;
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
 import static org.eclipse.microprofile.lra.tck.participant.api.AfterLRAListener.AFTER_LRA_LISTENER_WORK;
 import static org.eclipse.microprofile.lra.tck.participant.api.LraResource.ACCEPT_WORK;
-import static org.eclipse.microprofile.lra.tck.participant.api.LraResource.CANCEL_PATH;
 import static org.eclipse.microprofile.lra.tck.participant.api.LraResource.LRA_RESOURCE_PATH;
+import static org.eclipse.microprofile.lra.tck.participant.api.LraResource.CANCEL_PATH;
 import static org.eclipse.microprofile.lra.tck.participant.api.LraResource.TIME_LIMIT;
 import static org.eclipse.microprofile.lra.tck.participant.api.LraResource.TIME_LIMIT_HALF_SEC;
 import static org.eclipse.microprofile.lra.tck.participant.api.LraResource.TRANSACTIONAL_WORK_PATH;
@@ -64,7 +64,6 @@ import org.eclipse.microprofile.lra.tck.service.LRATestService;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -84,11 +83,6 @@ public class TckTests extends TckTestBase {
     @Deployment(name = "tcktests")
     public static WebArchive deploy() {
         return TckTestBase.deploy(TckTests.class.getSimpleName().toLowerCase());
-    }
-
-    @Before
-    public void before() {
-        super.before();
     }
 
     /**
@@ -225,6 +219,8 @@ public class TckTests extends TckTestBase {
     /**
      * TCK test to verify that methods annotated with {@link AfterLRA}
      * are notified correctly when an LRA terminates
+     *
+     * @throws InterruptedException when waiting for the finishing the callbacks is interrupted
      */
     @Test
     public void testAfterLRAParticipant() throws WebApplicationException, InterruptedException {

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraCancelOnResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraCancelOnResource.java
@@ -143,6 +143,7 @@ public class LraCancelOnResource {
      * will be called only once for the test invocation.
      * </p>
      * @param lraId The LRA id generated for this action
+     * @param uriInfo as context provided by JAX-RS to find base service URI
      * @return JAX-RS response
      */
     @GET

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/RecoveryResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/RecoveryResource.java
@@ -23,23 +23,16 @@ import org.eclipse.microprofile.lra.annotation.AfterLRA;
 import org.eclipse.microprofile.lra.annotation.Compensate;
 import org.eclipse.microprofile.lra.annotation.LRAStatus;
 import org.eclipse.microprofile.lra.annotation.ws.rs.LRA;
-import org.eclipse.microprofile.lra.tck.TckRecoveryTests;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricService;
 import org.eclipse.microprofile.lra.tck.service.LRAMetricType;
-import org.eclipse.microprofile.lra.tck.service.LRATestService;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import java.net.URI;
-import java.net.URL;
 import java.time.temporal.ChronoUnit;
 
 import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT_HEADER;
@@ -49,92 +42,12 @@ import static org.eclipse.microprofile.lra.annotation.ws.rs.LRA.LRA_HTTP_CONTEXT
 public class RecoveryResource {
 
     public static final String RECOVERY_RESOURCE_PATH = "recovery-resource";
-    public static final String PHASE_1 = "phase-1";
-    public static final String PHASE_2 = "phase-2";
-    public static final String LRA_HEADER = "LRA";
-    public static final String TRIGGER_RECOVERY = "triggerRecovery";
+    public static final String REQUIRED_PATH = "required";
+    public static final String REQUIRED_TIMEOUT_PATH = "required-timeout";
     public static final long LRA_TIMEOUT = 500;
-    private static final String REQUIRED_PATH = "required";
-    private static final String REQUIRED_TIMEOUT_PATH = "required-timeout";
 
     @Inject
     LRAMetricService lraMetricService;
-
-    @Inject
-    LRATestService lraTestService;
-
-    /**
-     * Starts a new LRA and enlists an instance of this class with it as a participant
-     *
-     * @param timeout whether or not the LRA should time out after 500 milliseconds
-     * @return response containing the LRA id of the newly started LRA
-     */
-    @GET
-    @Path(PHASE_1)
-    public Response phase1(@QueryParam("timeout") @DefaultValue("false") boolean timeout,
-                           @HeaderParam(TckRecoveryTests.LRA_TCK_DEPLOYMENT_URL) URL deploymentURL) {
-        
-        lraTestService.start(deploymentURL);
-        
-        // start a new LRA and join it with this resource
-        URI lra;
-        Response response;
-        
-
-        response = lraTestService.getTCKSuiteTarget().path(RecoveryResource.RECOVERY_RESOURCE_PATH)
-                .path(timeout ? RecoveryResource.REQUIRED_TIMEOUT_PATH : RecoveryResource.REQUIRED_PATH)
-                .request().put(Entity.text(""));
-
-        lra = URI.create(response.readEntity(String.class));
-
-        Response.ResponseBuilder responseBuilder = Response.ok(lra);
-        
-        return responseBuilder.build();
-    }
-
-    /**
-     * Cancels the supplied LRA and verifies that all required actions have been performed
-     * 
-     * @param lraId lra id of the LRA to be cancelled
-     * @return a {@link Response} object containing the optional error message 
-     */
-    @GET
-    @Path(PHASE_2)
-    public Response phase2(@HeaderParam(LRA_HEADER) URI lraId,
-                           @HeaderParam(TckRecoveryTests.LRA_TCK_DEPLOYMENT_URL) URL deploymentURL) {
-        lraTestService.start(deploymentURL);
-        lraTestService.getLRAClient().cancelLRA(lraId);
-        lraTestService.waitForCallbacks(lraId);
-
-        // assert compensate has been called
-        int compensations = lraMetricService.getMetric(LRAMetricType.Compensated, lraId, RecoveryResource.class.getName());
-        if (compensations < 1) {
-            return assertFailedResponse("Compensate on restarted service should have been called. Was " + compensations);
-        }
-
-        // assert after LRA has been called
-        int afterLRACalls = lraMetricService.getMetric(LRAMetricType.Cancelled, lraId, RecoveryResource.class.getName());
-        if (afterLRACalls < 1) {
-            return assertFailedResponse("After LRA with Cancelled status should have been called. Was " + afterLRACalls);
-        }
-
-        return Response.ok().build();
-    }
-
-    private Response assertFailedResponse(String message) {
-        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(message).build();
-    }
-
-    @GET
-    @Path(TRIGGER_RECOVERY)
-    public Response triggerRecovery(@HeaderParam(LRA_HEADER) URI lraId,
-                                    @HeaderParam(TckRecoveryTests.LRA_TCK_DEPLOYMENT_URL) URL deploymentURL) {
-        lraTestService.start(deploymentURL);
-        lraTestService.waitForRecovery(lraId);
-        return Response.ok().build();
-    } 
-
-    // LRA participant methods
 
     @PUT
     @Path(REQUIRED_PATH)

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRAMetricRest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRAMetricRest.java
@@ -1,0 +1,61 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.lra.tck.service;
+
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.net.URI;
+
+/**
+ * JAX-RS endpoints for the {@link LRAMetricService}.
+ */
+@Path(LRAMetricRest.LRA_TCK_METRIC_RESOURCE_PATH)
+public class LRAMetricRest {
+    public static final String LRA_TCK_METRIC_RESOURCE_PATH = "lra-tck-metric";
+    public static final String METRIC_PATH = "metric";
+
+    public static final String METRIC_TYPE_PARAM = "metricType";
+    public static final String LRA_ID_PARAM = "lraId";
+    public static final String PARTICIPANT_NAME_PARAM = "participantName";
+
+    @Inject
+    private LRAMetricService lraMetricService;
+
+    @Path(METRIC_PATH)
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public int getMetric(@QueryParam(METRIC_TYPE_PARAM) LRAMetricType metricType, @QueryParam(LRA_ID_PARAM) URI lra,
+                         @QueryParam(PARTICIPANT_NAME_PARAM) String participantName) {
+        if (metricType == null) {
+            throw new NullPointerException("metricType");
+        }
+        if (lra == null) {
+            throw new NullPointerException("lraId");
+        }
+        if (participantName == null) {
+            throw new NullPointerException("participantName");
+        }
+        return lraMetricService.getMetric(metricType, lra, participantName);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRATestService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRATestService.java
@@ -20,13 +20,11 @@
 package org.eclipse.microprofile.lra.tck.service;
 
 import org.eclipse.microprofile.lra.tck.LRAClientOps;
-import org.eclipse.microprofile.lra.tck.LraTckConfigBean;
 import org.eclipse.microprofile.lra.tck.service.spi.LRACallbackException;
 import org.eclipse.microprofile.lra.tck.service.spi.LRARecoveryService;
 import org.junit.Assert;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
@@ -34,12 +32,12 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.ServiceLoader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @ApplicationScoped
 public class LRATestService {
-
-    @Inject
-    LraTckConfigBean config;
+    private static final Logger LOG = Logger.getLogger(LRATestService.class.getName());
 
     private LRAClientOps lraClient;
 
@@ -73,6 +71,7 @@ public class LRATestService {
         try {
             lraRecoveryService.waitForCallbacks(lraId);
         } catch (LRACallbackException e) {
+            LOG.log(Level.SEVERE, "Fail to 'waitForCallbacks' for LRA " + lraId, e);
             Assert.fail(e.getMessage());
         }
     }
@@ -81,6 +80,7 @@ public class LRATestService {
         try {
             lraRecoveryService.waitForRecovery(lraId);
         } catch (LRACallbackException e) {
+            LOG.log(Level.SEVERE, "Fail to 'waitForRecovery' for LRA " + lraId, e);
             Assert.fail(e.getMessage());
         }
     }
@@ -89,6 +89,7 @@ public class LRATestService {
         try {
             lraRecoveryService.waitForEndPhaseReplay(lraId);
         } catch (LRACallbackException e) {
+            LOG.log(Level.SEVERE, "Fail to 'waitForEndPhaseReplay' for LRA " + lraId, e);
             Assert.fail(e.getMessage());
         }
     }


### PR DESCRIPTION
fixes #294 

One poinit is to emphasize the functionality of the `TckRecoveryTests`.
They were run out of container by Arquillian already. But it was not clear from the comment.
Changing the text and adding the annotation `@RunAsClient` in particular defines it clearer.

The other main point is to to refactor the TckRecoveryTests to split the resource and the test functionality.
The test functionality can be run out of the container and being part of the @Test. It's easier to read and understand the test purpose.

As the last one there are few minor refactoring fixes.