### PR TITLE
Don't set the lra header if it is null

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
@@ -343,10 +343,12 @@ public class TckContextTests extends TckTestBase {
                 .header(LRA_TCK_FAULT_CODE_HEADER, finishStatus);
         Response response;
 
-        if (where.startsWith(METRIC_PATH) || (where.startsWith(CLEAR_STATUS_PATH))) {
-            builder.header(LRA_TCK_HTTP_CONTEXT_HEADER, lraContext);
-        } else {
-            builder.header(LRA_HTTP_CONTEXT_HEADER, lraContext);
+        if (lraContext != null) {
+            if (where.startsWith(METRIC_PATH) || (where.startsWith(CLEAR_STATUS_PATH))) {
+                builder.header(LRA_TCK_HTTP_CONTEXT_HEADER, lraContext);
+            } else {
+                builder.header(LRA_HTTP_CONTEXT_HEADER, lraContext);
+            }
         }
 
         switch (method) {


### PR DESCRIPTION
If the JAX-RS client is apache-cxf, this results in header being set
with a value of the string 'null'. When the header is sent as part of
the test, it breaks the Narayana implementation

Signed-off-by: ilewis <ilewis@uk.ibm.com>