### PR TITLE
Fix two test bugs

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/LRAClientOps.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/LRAClientOps.java
@@ -246,7 +246,10 @@ public class LRAClientOps {
     }
 
     void cleanUp(Logger logger, String testName) {
-        lraTasks.forEach((lra, future) -> {
+        // cancelCancelation removes items from the lraTasks map, so a copy is
+        // needed to prevent a ConcurrentModificationException
+        Map<LRATask, ScheduledFuture<?>> taskCopy = new HashMap<>(lraTasks);
+        taskCopy.forEach((lra, future) -> {
             logger.warning("Test: " + testName + " didn't finish LRA " + lra.lra + " with clientId " + lra.clientId);
             cancelLRA(lra.lra);
         });

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckLRATypeTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckLRATypeTests.java
@@ -628,9 +628,7 @@ public class TckLRATypeTests extends TckTestBase {
             }
 
             return methodLraId;
-        } catch (Throwable e) {
-            LOGGER.warning(e.getMessage());
-            return null;
+
         } finally {
             response.close();
         }


### PR DESCRIPTION
In TckLRATypeTests, the resourceRequest method is catching 'Throwable'.
This means it will catch any assertions thrown inside the method, which
will hide test failures.

in LRAClientOps, the cleanUp method is vulnerable to ConcurrentModificationException
as the cancelCancelation method may cause entries to be removed from the lraTasks
map, while it is being iterated over.

Signed-off-by: ilewis <ilewis@uk.ibm.com>