### PR TITLE
Fix the race condition in the TckParticipantTests.cancelLraDuringBusi…

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/nonjaxrs/valid/LongBusinessMethodParticipant.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/nonjaxrs/valid/LongBusinessMethodParticipant.java
@@ -62,7 +62,7 @@ public class LongBusinessMethodParticipant {
 
     @PUT
     @Path(BUSINESS_METHOD)
-    @LRA(value = LRA.Type.MANDATORY)
+    @LRA(value = LRA.Type.MANDATORY, end = false)
     public Response enlistWithLongLatency(@HeaderParam(LRA.LRA_HTTP_CONTEXT_HEADER) URI lraId) {
         LOGGER.info("call of enlistWithLongLatency");
         try {


### PR DESCRIPTION
…nessMethod

I hit this race condition in the testing of new spec versions. [This test](https://github.com/eclipse/microprofile-lra/blob/master/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckParticipantTests.java#L182) performs a manual cancel of the started LRA at [line 208](https://github.com/eclipse/microprofile-lra/blob/master/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckParticipantTests.java#L208). However, the invoked [method](https://github.com/eclipse/microprofile-lra/blob/da32f5220858ca93eb4814303284821aaf557312/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/nonjaxrs/valid/LongBusinessMethodParticipant.java#L66) in the LongBusinessMethodParticipant class is annotated with default LRA annotation that attempts to close the LRA when the method finishes. This introduces conflict and a race condition between the latch await and automatic Close of the LRA and between manual Cancel of the LRA in the test. A simple fix is just to not close the LRA automatically in the LRA method.