### PR TITLE
Fix build warnings

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/lra/LRAResponse.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/LRAResponse.java
@@ -23,13 +23,13 @@ package org.eclipse.microprofile.lra;
 import javax.ws.rs.core.Response;
 
 /**
- * The utility class that will create the correct {@link Response} or {@link Response.ResponseBuilder}
+ * The utility class that will create the correct {@link Response} or {@link javax.ws.rs.core.Response.ResponseBuilder}
  * for the response that should be returned from the LRA JAX-RS methods.
  */
 public final class LRAResponse {
-    
+
     private LRAResponse() {}
-    
+
     public static Response compensated() {
         return Builder.compensated().build();
     }
@@ -37,7 +37,7 @@ public final class LRAResponse {
     public static Response compensated(Object entity) {
         return Builder.compensated(entity).build();
     }
-    
+
     public static Response compensating() {
         return Builder.compensating().build();
     }
@@ -45,7 +45,7 @@ public final class LRAResponse {
     public static Response compensating(Object entity) {
         return Builder.compensating(entity).build();
     }
-    
+
     public static Response failedToCompensate() {
         return Builder.failedToCompensate().build();
     }
@@ -53,7 +53,7 @@ public final class LRAResponse {
     public static Response failedToCompensate(Object entity) {
         return Builder.failedToCompensate(entity).build();
     }
-    
+
     public static Response completed() {
         return Builder.completed().build();
     }
@@ -61,7 +61,7 @@ public final class LRAResponse {
     public static Response completed(Object entity) {
         return Builder.completed(entity).build();
     }
-    
+
     public static Response completing() {
         return Builder.completing().build();
     }
@@ -69,7 +69,7 @@ public final class LRAResponse {
     public static Response completing(Object entity) {
         return Builder.completing(entity).build();
     }
-    
+
     public static Response failedToComplete() {
         return Builder.failedToComplete().build();
     }
@@ -77,7 +77,7 @@ public final class LRAResponse {
     public static Response failedToComplete(Object entity) {
         return Builder.failedToComplete(entity).build();
     }
-    
+
     public static final class Builder {
         public static Response.ResponseBuilder compensated() {
             return Response.ok();

--- a/api/src/main/java/org/eclipse/microprofile/lra/annotation/Forget.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/annotation/Forget.java
@@ -39,8 +39,8 @@ import java.lang.annotation.Target;
  *
  * <p>
  * Similar remarks apply if the participant was enlisted in a
- * nested LRA ({@link LRA.Type#NESTED}). Actions performed in the context
- * of a nested LRA must remain compensatable until the participant
+ * nested LRA ({@link org.eclipse.microprofile.lra.annotation.ws.rs.LRA.Type#NESTED}).
+ * Actions performed in the context of a nested LRA must remain compensatable until the participant
  * is explicitly told it can clean up using this <code>&#64;Forget</code>
  * annotation.
  * </p>
@@ -70,7 +70,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * <p>
- * would be a valid forget method declaration. If an invalid signature is detected 
+ * would be a valid forget method declaration. If an invalid signature is detected
  * the implementation of this specification MUST prohibit successful startup of the application
  * (e.g. with a runtime exception).
  * </p>

--- a/api/src/main/java/org/eclipse/microprofile/lra/annotation/ws/rs/LRA.java
+++ b/api/src/main/java/org/eclipse/microprofile/lra/annotation/ws/rs/LRA.java
@@ -63,7 +63,7 @@ import java.time.temporal.ChronoUnit;
  *   <li>to cancel the LRA context when the method returns particular HTTP
  *       status codes</li>
  * </ul>
- * 
+ *
  * Some of the above defined LRA operations are performed before the execution
  * proceeds to the LRA annotated business method. If any of these LRA operations
  * cannot complete the implementation MUST return one of the defined HTTP status
@@ -271,7 +271,8 @@ public @interface LRA {
          *     LRA present, a new nested LRA is started whose outcome depends upon
          *     whether or not the enclosing LRA is closed or cancelled.
          *     The id of the parent LRA MUST be present in the header with the name
-         *     {@value LRA_HTTP_PARENT_CONTEXT_HEADER} and the value is of type {@link java.net.URI}.
+         *     {@value org.eclipse.microprofile.lra.annotation.ws.rs.LRA#LRA_HTTP_PARENT_CONTEXT_HEADER}
+         *     and the value is of type {@link java.net.URI}.
          * </p>
          *
          * <p>
@@ -324,8 +325,8 @@ public @interface LRA {
          *     the top level parent LRA is then told to cancel the nested participants
          *     will be told to compensate. This implies that the nested participants
          *     must be aware that they are nested and the JAX-RS header with the
-         *     name {@value #LRA_HTTP_PARENT_CONTEXT_HEADER} is guaranteed to hold
-         *     the parent context whenever a nested LRA is being propagated.
+         *     name {@value org.eclipse.microprofile.lra.annotation.ws.rs.LRA#LRA_HTTP_PARENT_CONTEXT_HEADER}
+         *     is guaranteed to hold the parent context whenever a nested LRA is being propagated.
          * </p>
          *
          * <p>
@@ -420,7 +421,7 @@ public @interface LRA {
      * in a {@link Response} or via a JAX-RS exception mappper.
      * </p>
      *
-     * @return the {@link Response.Status.Family} status families that will cause
+     * @return the {@link javax.ws.rs.core.Response.Status.Family} status families that will cause
      * cancellation of the LRA
      */
     Response.Status.Family[] cancelOnFamily() default {
@@ -444,7 +445,7 @@ public @interface LRA {
      * codes in a {@link Response} or via a JAX-RS exception mappper.
      * </p>
      *
-     * @return the {@link Response.Status} HTTP status codes that will cause
+     * @return the {@link javax.ws.rs.core.Response.Status} HTTP status codes that will cause
      * cancellation of the LRA
      */
     Response.Status[] cancelOn() default {};

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <eclipse-jarsigner-plugin.version>1.1.4</eclipse-jarsigner-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
         <apache-rat-plugin.version>0.13</apache-rat-plugin.version>

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
@@ -61,8 +61,8 @@ import static org.eclipse.microprofile.lra.tck.participant.api.ContextTckResourc
 import static org.eclipse.microprofile.lra.tck.participant.api.ContextTckResource.RESET_PATH;
 import static org.eclipse.microprofile.lra.tck.participant.api.ContextTckResource.STATUS_PATH;
 import static org.eclipse.microprofile.lra.tck.participant.api.ContextTckResource.TCK_CONTEXT_RESOURCE_PATH;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 /**
  * test that Compensate, Complete, Status, Forget and Leave annotations work without an LRA annotation

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckInvalidSignaturesTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckInvalidSignaturesTests.java
@@ -35,23 +35,24 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertThrows;
 
 /**
  * <p>
  * TCK that verifies that invalid non-JAX-RS participant method signatures are reported during deployment
  * </p>
- * 
+ *
  * <p>
- * Each test deploys an archive containing single invalid participant containing an error in its participant 
+ * Each test deploys an archive containing single invalid participant containing an error in its participant
  * method signature and expects that such deployment is aborted according to the specification.
  * </p>
  */
 @RunWith(Arquillian.class)
 public class TckInvalidSignaturesTests {
-    
+
     private static final String INVALID_RETURN_TYPE_DEPLOYMENT = "nonjaxrs-return-type-deploy";
     private static final String TOO_MANY_ARGS_DEPLOYMENT = "too-many-args-deploy";
     private static final String INVALID_ARGUMENT_TYPE_DEPLOYMENT = "nonjaxrs-argument-type-deploy";
@@ -59,14 +60,11 @@ public class TckInvalidSignaturesTests {
     private static final String INVALID_LRA_RESOURCE_DEPLOYMENT = "invalid-lra-resource-deploy";
 
     @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Rule
     public DeploymentNameRule deploymentNameRule = new DeploymentNameRule();
 
     @ArquillianResource
     private Deployer deployer;
-    
+
     @Deployment(name = INVALID_RETURN_TYPE_DEPLOYMENT, managed = false)
     public static WebArchive deployInvalidReturnTypeParticipant() {
         return createArchive(InvalidReturnTypeParticipant.class);
@@ -81,7 +79,7 @@ public class TckInvalidSignaturesTests {
     public static WebArchive deployInvalidArgumentTypeParticipant() {
         return createArchive(InvalidArgumentTypesParticipant.class);
     }
-    
+
     @Deployment(name = INVALID_AFTER_LRA_SIGNATURE_DEPLOYMENT, managed = false)
     public static WebArchive deployInvalidAfterLRASignatureResource() {
         return createArchive(InvalidAfterLRASignatureListener.class);
@@ -99,7 +97,7 @@ public class TckInvalidSignaturesTests {
             .addClasses(resourceClass, JaxRsActivator.class)
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
-    
+
     @After
     public void after() {
         deployer.undeploy(deploymentNameRule.deploymentName);
@@ -147,13 +145,11 @@ public class TckInvalidSignaturesTests {
 
     private void testInvalidDeployment(String deploymentName) {
         deploymentNameRule.deploymentName = deploymentName;
-        expectedException.expect(DeploymentException.class);
-
-        deployer.deploy(deploymentName);
+        assertThrows(DeploymentException.class, () -> deployer.deploy(deploymentName));
     }
 
     private static final class DeploymentNameRule extends TestName {
-        
+
         String deploymentName;
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckRecoveryTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckRecoveryTests.java
@@ -49,7 +49,7 @@ import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * <p>
@@ -66,27 +66,27 @@ import static org.junit.Assert.assertThat;
 @RunAsClient
 public class TckRecoveryTests {
     private static final Logger LOG = Logger.getLogger(TckRecoveryTests.class.getName());
-    
+
     private static final String DEPLOYMENT_NAME = "tck-recovery";
     private static final Logger LOGGER = Logger.getLogger(TckRecoveryTests.class.getName());
 
     @ArquillianResource
     private Deployer deployer;
-    
+
     private LRATestService lraTestService;
     private Client deploymentClient;
     private WebTarget deploymentTarget;
 
     @Rule
     public TestName testName = new TestName();
-        
+
     @Before
     public void before() {
         LOGGER.info("Running test: " + testName.getMethodName());
         // deploy the test service
         deployer.deploy(DEPLOYMENT_NAME);
     }
-    
+
     @After
     public void after() {
         try {
@@ -108,13 +108,15 @@ public class TckRecoveryTests {
      * This test verifies that if the microservice application fails after
      * it enlists with a LRA and then it is restarted again the Compensate
      * callbacks are still received correctly.
-     * 
+     *
      * Scenario:
      * - start a new container with a single LRA resource
      * - start a new LRA and enlist LRA resource
      * - kill the container/application
      * - start the container/application
      * = cancel the LRA and verify that the callbacks have been sent
+     *
+     * @param deploymentURL the URL of the arquillian deployment
      */
     @Test
     public void testCancelWhenParticipantIsRestarted(@ArquillianResource URL deploymentURL) {
@@ -149,7 +151,7 @@ public class TckRecoveryTests {
      * enlisted with the LRA fails and the LRA is ended during the time
      * the service is still down, the Compensate callbacks are received
      * when the microservice application is started again.
-     * 
+     *
      * Scenario:
      * - start a new container with a single LRA resource
      * - start a new LRA and enlist the LRA resource with it
@@ -158,6 +160,8 @@ public class TckRecoveryTests {
      * - start the container again
      * - replay the end phase to get Compensate calls redelivered
      * - verify that the Compensate callbacks have been received
+     *
+     * @param deploymentURL the URL of the arquillian deployment
      */
     @Test
     public void testCancelWhenParticipantIsUnavailable(@ArquillianResource URL deploymentURL) {
@@ -174,7 +178,7 @@ public class TckRecoveryTests {
 
         // kill the test service while LRA is still active
         deployer.undeploy(DEPLOYMENT_NAME);
-        
+
         // Wait for the timeout cancellation of the LRA. This will put the LRA into cancel only state.
         // Then wait for the short delay to actually perform the cancellation while the service is still down.
         // Compensate should be attempted to be called while the participant service is down
@@ -189,7 +193,7 @@ public class TckRecoveryTests {
 
         // start the test service again
         deployer.deploy(DEPLOYMENT_NAME);
-        
+
         // trigger recovery causing the Compensate call to be replayed
         lraTestService.waitForRecovery(lra);
 

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckTests.java
@@ -29,7 +29,6 @@ import org.eclipse.microprofile.lra.tck.participant.api.ParticipatingTckResource
 import org.eclipse.microprofile.lra.tck.service.LRAMetricAssertions;
 import org.eclipse.microprofile.lra.tck.service.LRATestService;
 import org.hamcrest.Matchers;
-import org.hamcrest.core.IsEqual;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -60,11 +59,11 @@ import static org.eclipse.microprofile.lra.tck.participant.api.LraResource.TRANS
 import static org.eclipse.microprofile.lra.tck.participant.api.ParticipatingTckResource.JOIN_WITH_EXISTING_LRA_PATH;
 import static org.eclipse.microprofile.lra.tck.participant.api.ParticipatingTckResource.JOIN_WITH_EXISTING_LRA_PATH2;
 import static org.eclipse.microprofile.lra.tck.participant.api.ParticipatingTckResource.TCK_PARTICIPANT_RESOURCE_PATH;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -76,7 +75,7 @@ public class TckTests extends TckTestBase {
 
     @Inject
     private LRATestService lraTestService;
-    
+
     private enum CompletionType {
         complete, compensate, mixed
     }
@@ -135,21 +134,21 @@ public class TckTests extends TckTestBase {
                     .request()
                     .header(LRA_HTTP_CONTEXT_HEADER, lra)
                     .put(Entity.text(""));
-    
+
             assertEquals("Response status to ' " + resourcePath.getUri() + "' does not match.",
                     Response.Status.OK.getStatusCode(), response.getStatus());
-    
+
             Object parentId = response.getHeaders().getFirst(LRA_HTTP_CONTEXT_HEADER);
-    
+
             assertNotNull("Expecting to get parent LRA id as response from " + resourcePath.getUri(), parentId);
             assertEquals("The nested activity should return the parent LRA id. The call to " + resourcePath.getUri(),
                     parentId, lra.toString());
-    
+
             URI nestedLraId = URI.create(response.readEntity(String.class)); // We can keep String.class here as it is in TCK
-    
+
             // close the LRA
             lraClient.closeLRA(lra);
-    
+
             // validate that the nested LRA was closed
 
             // the resource /activities/work is annotated with Type.REQUIRED so the container should have ended it
@@ -159,7 +158,7 @@ public class TckTests extends TckTestBase {
             if(response != null) {
                 response.close();
             }
-        } 
+        }
     }
 
     @Test
@@ -194,7 +193,7 @@ public class TckTests extends TckTestBase {
         // close the LRA
         lraClient.closeLRA(lra);
         lraTestService.waitForCallbacks(lra);
-        
+
         // check that participant was told to complete
         lraMetric.assertCompletedEquals("Wrong completion count for call " + resourcePath.getUri() +
                 ". Expecting the method LRA was completed after joining the existing LRA " + lra,
@@ -325,7 +324,7 @@ public class TckTests extends TckTestBase {
 
         // check that participant was invoked
         lraTestService.waitForCallbacks(lraId);
-        
+
         /*
          * The call to activities/timeLimit should have started an LRA which should have timed out
          * (because the invoked resource method sleeps for longer than the timeLimit annotation
@@ -337,7 +336,7 @@ public class TckTests extends TckTestBase {
                 lraId, LraResource.class);
         lraMetric.assertCompensatedEquals("The LRA should have timed out and compensate should be called. "
                 + "Expecting the number of compensate call before test is one less lower than the ones after LRA timed out. "
-                + "The test call went to " + resourcePath.getUri(), 
+                + "The test call went to " + resourcePath.getUri(),
                 1, lraId, LraResource.class);
     }
 
@@ -359,8 +358,8 @@ public class TckTests extends TckTestBase {
                 .get();
 
         assertThat("Expected 412 or 410 response", response.getStatus(),
-                Matchers.anyOf(new IsEqual(Response.Status.PRECONDITION_FAILED.getStatusCode()),
-                               new IsEqual(Response.Status.GONE.getStatusCode())));
+                Matchers.anyOf(Matchers.is(Response.Status.PRECONDITION_FAILED.getStatusCode()),
+                               Matchers.is(Response.Status.GONE.getStatusCode())));
 
         response.close();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckUnknownTests.java
@@ -40,7 +40,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * TCK Tests related to the 410 status code handling. Version without a Status method.
@@ -83,7 +83,7 @@ public class TckUnknownTests extends TckTestBase {
     public void compensate_retry() throws WebApplicationException {
         String lraIdString = invoke(Scenario.COMPENSATE_RETRY);
         URI lraId = URI.create(lraIdString);
-        
+
         lraTestService.waitForRecovery(lraId);
 
         int compensatedCalled = lraMetricService.getMetric(LRAMetricType.Compensated,

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraResource.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/LraResource.java
@@ -360,6 +360,8 @@ public class LraResource extends ResourceParent {
     /**
      * Used to close nested LRA in which this resource is enlisted
      *
+     * @param lraId the id of the LRA
+     * @return the JAX-RS response indicating that LRA should be cancelled
      * @see org.eclipse.microprofile.lra.tck.TckTests#mixedMultiLevelNestedActivity
      */
     @PUT
@@ -430,6 +432,11 @@ public class LraResource extends ResourceParent {
     }
 
     /**
+     * Starts an LRA with the time limit and verifies that after the timelimit is passed the
+     * LRA is finished by the invocation to a mandatory LRA endpoint (which should fail with 412)
+     *
+     * @param lraId the id of the LRA
+     * @return the JAX-RS response 200 if successful or the received HTTP status call otherwise
      * @see org.eclipse.microprofile.lra.tck.TckTests#timeLimitWithPreConditionFailed
      */
     @GET

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRAMetricAssertions.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/service/LRAMetricAssertions.java
@@ -25,8 +25,8 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 import java.net.URI;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**


### PR DESCRIPTION
Signed-off-by: xstefank <xstefank122@gmail.com>

Please note that formating changes are due to the `.editorconfig` file that now setups IDEs to remove trailing spaces. This will eventually be done in all saved files so we can do it in one PR if requested but not necessary.