### PR TITLE
jax-rs compatibility

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/TckContextTests.java
@@ -297,7 +297,7 @@ public class TckContextTests extends TckTestBase {
             .path(AfterLRAListener.AFTER_LRA_LISTENER_WORK)
             .request()
             .header(LRA_HTTP_CONTEXT_HEADER, lra)
-            .put(null);
+            .put(Entity.text(""));
 
         assertEquals("AfterLRA listener hasn't been enlisted for the notification",
             200, enlistResponse.getStatus());

--- a/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/AfterLRAListener.java
+++ b/tck/src/main/java/org/eclipse/microprofile/lra/tck/participant/api/AfterLRAListener.java
@@ -63,7 +63,7 @@ public class AfterLRAListener extends ResourceParent {
     @PUT
     @Path(AFTER_LRA)
     @AfterLRA // this method will be called when the LRA associated with the method activityWithLRA finishes
-    public Response afterEnd(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus status) {
+    public Response afterLRA(@HeaderParam(LRA_HTTP_ENDED_CONTEXT_HEADER) URI lraId, LRAStatus status) {
         return lraTestService.processAfterLRAInfo(lraId, status, AfterLRAListener.class,
             AFTER_LRA_LISTENER_PATH + AFTER_LRA);
     }


### PR DESCRIPTION
Replace implementation specific constructs 

* Ambiguous paths of not overridden jax-rs methods #346
* Put with empty body (null is not supported by Jersey)

Fixes #346